### PR TITLE
Pkg name

### DIFF
--- a/src/rebar3_hex_pkg.erl
+++ b/src/rebar3_hex_pkg.erl
@@ -126,12 +126,7 @@ publish(AppDir, Name, Version, Deps, Excluded, AppDetails) ->
     %% We check the app file for the 'pkg' key wich allows us to select
     %% a package name other then the app anem, if it is not set we default
     %% back to the app name.
-    PkgName = case proplists:get_value(pkg, AppDetails) of
-                  undefined ->
-                      Name;
-                  PkgNameS ->
-                      list_to_binary(PkgNameS)
-              end,
+    PkgName = ec_cnv:to_binary(proplists:get_value(pkg_name, AppDetails, Name)),
 
     Optional = [{app, Name}
                ,{requirements, Deps}


### PR DESCRIPTION
This adds the `pkg_name` option in the app.src file, this way it's possible to have a package name that differs from the app name.
