### PR TITLE
Fix `rebar3 hex user reset_password`

### DIFF
--- a/src/rebar3_hex_http.erl
+++ b/src/rebar3_hex_http.erl
@@ -53,6 +53,8 @@ post_map(Path, Auth, Body) ->
                       ,[{ssl, rebar_api:ssl_opts(rebar3_hex_config:api_url())}]
                       ,[{body_format, binary}]
                       ,hex) of
+        {ok, {{_, 204, _}, _, <<>>}} ->
+            ok;
         {ok, {{_, Status, _}, _, RespBody}} when Status >= 200, Status =< 299 ->
             {ok, binary_to_term(RespBody)};
         {ok, {{_, Status, _}, _, _}} when Status >= 500->

--- a/src/rebar3_hex_user.erl
+++ b/src/rebar3_hex_user.erl
@@ -99,7 +99,7 @@ deauth() ->
 
 reset_password() ->
     User = ec_talk:ask_default("Username or Email:", string, ""),
-    rebar3_hex_http:post_map(filename:join([?ENDPOINT, User, "reset"]), [], []).
+    ok = rebar3_hex_http:post_map(filename:join([?ENDPOINT, User, "reset"]), [], maps:new()).
 
 %% Internal functions
 


### PR DESCRIPTION
This entails:
- passing an empty map instead of empty list to API endpoint;
- fix handling of 204 No Content in rebar3_hex_http:post_map/3.
