### PR TITLE
Fix for hex docs

### DIFF
--- a/src/rebar3_hex_docs.erl
+++ b/src/rebar3_hex_docs.erl
@@ -86,7 +86,7 @@ delete(Name, Version) ->
     end.
 
 file_list(Files) ->
-    [{drop_path(File, ["doc"]), File} || File <- Files].
+    [{drop_path(ShortName, ["doc"]), FullName} || {ShortName, FullName} <- Files].
 
 drop_path(File, Path) ->
     filename:join(filename:split(File) -- Path).


### PR DESCRIPTION
rebar3 hex docs blows up when trying to drop "doc" from the short path name.
