### PR TITLE
Added NOTICE to default files.

### DIFF
--- a/src/rebar3_hex.hrl
+++ b/src/rebar3_hex.hrl
@@ -3,7 +3,8 @@
 -define(DEFAULT_FILES, ["src", "c_src", "include", "rebar.config.script"
                        ,"priv", "rebar.config", "rebar.lock"
                        ,"README*", "readme*"
-                       ,"LICENSE*", "license*"]).
+                       ,"LICENSE*", "license*"
+                       ,"NOTICE"]).
 
 -define(CHUNK, 10000).
 


### PR DESCRIPTION
Apache 2.0 license supports adding a NOTICE file which should be distributed with the software: http://www.apache.org/dev/licensing-howto.html#mod-notice . Added NOTICE to default files to support that.
