### PR TITLE
Fix error reporting for bad requirements

### DIFF
--- a/src/rebar3_hex_pkg.erl
+++ b/src/rebar3_hex_pkg.erl
@@ -15,6 +15,10 @@
 
 -define(ENDPOINT, "packages").
 
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
 %% ===================================================================
 %% Public API
 %% ===================================================================
@@ -219,11 +223,15 @@ upload_package(Auth, Name, Version, Meta, Files) ->
 
 errors_to_string(Value) when is_binary(Value) ->
     Value;
-errors_to_string({Key, Value}) ->
-    io_lib:format("~s: ~s", [Key, errors_to_string(Value)]);
-errors_to_string(#{<<"requirements">> := Rs}) ->
+errors_to_string(Map) when is_map(Map) ->
+    errors_to_string(maps:to_list(Map));
+errors_to_string({<<"inserted_at">>, E}) ->
+    lists:flatten(io_lib:format("Inserted At: ~s~n", [E]));
+errors_to_string({<<"requirements">>,  Rs}) ->
     lists:flatten(["Requirements could not be computed\n",
                   [io_lib:format("~s\n~20.20c\n~s\n",[P,$-, R]) || {P, R} <- maps:to_list(Rs)]]);
+errors_to_string({Key, Value}) ->
+    io_lib:format("~s: ~s", [Key, errors_to_string(Value)]);
 errors_to_string(Errors) when is_list(Errors) ->
     lists:flatten([io_lib:format("~s", [errors_to_string(Values)]) || Values <- Errors]).
 
@@ -251,3 +259,12 @@ update_versions(ConfigDeps, Deps) ->
                  {N, maps:from_list(M)}
          end
      end || {N, M} <- Deps].
+
+-ifdef(TEST).
+
+error_test() ->
+    E = #{<<"inserted_at">> => <<"can only modify a release up to one hour after creation">>,
+          <<"requirements">> => #{nil => <<"Failed to use \"lager\" (version 3.0.2) because\n  rebar.config requires 3.0.2\n  rebar.config requires ~>3.2.0\n">>}},
+    ?assert(is_list(errors_to_string(E))).
+
+-endif.

--- a/src/rebar3_hex_pkg.erl
+++ b/src/rebar3_hex_pkg.erl
@@ -221,6 +221,9 @@ errors_to_string(Value) when is_binary(Value) ->
     Value;
 errors_to_string({Key, Value}) ->
     io_lib:format("~s: ~s", [Key, errors_to_string(Value)]);
+errors_to_string(#{<<"requirements">> := Rs}) ->
+    lists:flatten(["Requirements could not be computed\n",
+                  [io_lib:format("~s\n~20.20c\n~s\n",[P,$-, R]) || {P, R} <- maps:to_list(Rs)]]);
 errors_to_string(Errors) when is_list(Errors) ->
     lists:flatten([io_lib:format("~s", [errors_to_string(Values)]) || Values <- Errors]).
 


### PR DESCRIPTION
This patch fixes the error output when dependencies can't be resolve on hex.pm the output looks like this:

```
===> Status Code: Validation failed (422)
Hex Error: Validation error(s)
    Requirements could not be computed
basho_exometer_core
--------------------
Failed to use "lager" (version 3.0.1) because
  basho_exometer_core (version 1.0.1) requires ~>3.0.0
  cuttlefish (version 2.0.7) requires 3.0.2
  rebar.config requires ~>3.0.0

Failed to use "lager" (version 3.0.2) because
  basho_exometer_core (version 1.0.1) requires ~>3.0.0
  cuttlefish (version 2.0.7) requires 3.0.2
  rebar.config requires ~>3.0.0
  riak_ensemble_ng (version 2.2.0) requires 3.2.1
```
