### PR TITLE
Quick and dirty hacks: fix a few bad match errors

### DIFF
--- a/src/rebar3_hex_pkg.erl
+++ b/src/rebar3_hex_pkg.erl
@@ -253,7 +253,7 @@ format_build_tools(BuildTools) ->
 update_versions(ConfigDeps, Deps) ->
     [begin
          case lists:keyfind(binary_to_atom(N, utf8), 1, ConfigDeps) of
-             {_, V} ->
+             {_, V} when is_list(V) ->
                  {N, maps:from_list(lists:keyreplace(<<"requirement">>, 1, M, {<<"requirement">>, list_to_binary(V)}))};
              _ ->
                  {N, maps:from_list(M)}


### PR DESCRIPTION
This enables me to publish packages to Hex again. Not sure how long this has
been broken.. I'm on rebar 3.3.2 / OTP 19.1 atm fwiw.

These obviously need to be amended, but might be helpful to someone else in the meantime.