### PR TITLE
Support Unicode strings in app. description and package metadata

### DIFF
--- a/src/rebar3_hex_pkg.erl
+++ b/src/rebar3_hex_pkg.erl
@@ -136,7 +136,7 @@ publish(AppDir, Name, Version, Deps, [], AppDetails) ->
     ConfigDeps = proplists:get_value(deps, Config, []),
     Deps1 = update_versions(ConfigDeps, Deps),
 
-    Description = list_to_binary(proplists:get_value(description, AppDetails, "")),
+    Description = unicode:characters_to_binary(proplists:get_value(description, AppDetails, "")),
     FilePaths = proplists:get_value(files, AppDetails, ?DEFAULT_FILES),
     IncludeFilePaths = proplists:get_value(include_files, AppDetails, []),
     ExcludeFilePaths = proplists:get_value(exclude_files, AppDetails, []),

--- a/src/rebar3_hex_utils.erl
+++ b/src/rebar3_hex_utils.erl
@@ -45,9 +45,9 @@ binarify(Term) when is_atom(Term) ->
 binarify([]) ->
     [];
 binarify(Term) when is_list(Term) ->
-    case io_lib:printable_list(Term) of
+    case io_lib:printable_unicode_list(Term) of
         true ->
-            list_to_binary(Term);
+            unicode:characters_to_binary(Term);
         false ->
             [binarify(X) || X <- Term]
     end;


### PR DESCRIPTION
Hi,

I caught this upon trying to publish a package which included a (>255) Unicode codepoint in the application description - it triggered a crash.