### PR TITLE
Fix `rebar3 hex info *` commands

### DIFF
--- a/src/rebar3_hex_http.erl
+++ b/src/rebar3_hex_http.erl
@@ -93,23 +93,29 @@ pretty_print_status(Code) -> io_lib:format("HTTP status code: ~p", [Code]).
 
 %% Internal Functions
 
+%% @doc Only include authorization header if Auth key is not empty
+headers([]) ->
+    [{"user-agent", user_agent()}
+    ,{"Accept", "application/vnd.hex+erlang"} %% Erlang media type
+    ];
+headers(Auth) ->
+    [{"authorization",  ec_cnv:to_list(Auth)}
+     |headers([])].
+
 request(Path, Auth) ->
     {ec_cnv:to_list(rebar3_hex_config:api_url()) ++ ec_cnv:to_list(filename:join(?ENDPOINT, Path))
-    ,[{"authorization",  ec_cnv:to_list(Auth)}, {"user-agent", user_agent()}
-     , {"Accept", "application/vnd.hex+erlang"}]}.
+    ,headers(Auth)}.
 
 map_request(Path, Auth, Body) ->
     {ec_cnv:to_list(rebar3_hex_config:api_url()) ++ ec_cnv:to_list(filename:join(?ENDPOINT, Path))
-    ,[{"authorization",  ec_cnv:to_list(Auth)}, {"user-agent", user_agent()},
-      {"Accept", "application/vnd.hex+erlang"}]
+    ,headers(Auth)
     ,"application/vnd.hex+erlang", term_to_binary(Body)}.
 
 
 file_request(Path, Auth, Body, ContentLength) ->
     {ec_cnv:to_list(rebar3_hex_config:api_url()) ++ ec_cnv:to_list(filename:join(?ENDPOINT, Path))
-    ,[{"authorization", ec_cnv:to_list(Auth)}
-     ,{"content-length", ContentLength}, {"user-agent", user_agent()},
-      {"Accept", "application/vnd.hex+erlang"}] %%Erlang media type
+    ,[{"content-length", ContentLength}
+      |headers(Auth)]
     ,"application/octet-stream", {Body, 0}}.
 
 maybe_setup_proxy() ->

--- a/src/rebar3_hex_info.erl
+++ b/src/rebar3_hex_info.erl
@@ -163,8 +163,9 @@ package(Package) ->
             ec_talk:say(Description, []);
         {error, 404} ->
             rebar_api:error("No package with name ~s", [Package]);
-        _ ->
-            rebar_api:error("Failed to retrieve package information")
+        {error, Status} ->
+            rebar_api:error("Failed to retrieve package information: ~s",
+                            [rebar3_hex_http:pretty_print_status(Status)])
     end.
 
 
@@ -175,8 +176,9 @@ release(Package, Version) ->
             ec_talk:say("  Dependencies:\n    ~s", [req_join(Map)]);
         {error, 404} ->
             rebar_api:error("No package with name ~s", [Package]);
-        _ ->
-            rebar_api:error("Failed to retrieve package information")
+        {error, Status} ->
+            rebar_api:error("Failed to retrieve package information: ~s",
+                            [rebar3_hex_http:pretty_print_status(Status)])
     end.
 
 join(List) ->

--- a/src/rebar3_hex_info.erl
+++ b/src/rebar3_hex_info.erl
@@ -62,7 +62,7 @@ general(State) ->
 display([], _, _State) ->
     ok;
 
-display([{Name, Vsn} | Deps], Listed, State) when is_list(Vsn) ->
+display([{Name, Vsn} | Deps], Listed, State) when is_list(Vsn); is_binary(Vsn) ->
     ec_talk:say("~s ~s", [Name, Vsn]),
     %% accumulates already listed deps
     NewListed = [{Name, Vsn} | Listed],

--- a/src/rebar3_hex_owner.erl
+++ b/src/rebar3_hex_owner.erl
@@ -80,6 +80,7 @@ list(Package) ->
             ec_talk:say("~s", [OwnersString]);
         {error, 404} ->
             rebar_api:error("No package with name ~s", [Package]);
-        _ ->
-            rebar_api:error("Failed to retrieve package information", [])
+        {error, Status} ->
+            rebar_api:error("Failed to retrieve package information: ~s",
+                            [rebar3_hex_http:pretty_print_status(Status)])
     end.


### PR DESCRIPTION
- hex info commands were failing with authentication error (probably because some recent change on hex.pm server)
- printing the error message was also crashing