### PR TITLE
Change api_url to contain /api endpoint

### DIFF
--- a/src/rebar3_hex_config.erl
+++ b/src/rebar3_hex_config.erl
@@ -19,7 +19,7 @@
 -define(DEPS, []).
 
 -define(DEFAULT_HEX_CONFIG, "hex.config").
--define(DEFAULT_API_URL, "https://hex.pm").
+-define(DEFAULT_API_URL, "https://hex.pm/api").
 -define(DEFAULT_CDN_URL, "https://s3.amazonaws.com/s3.hex.pm").
 
 -spec init(rebar_state:t()) -> {ok, rebar_state:t()}.

--- a/src/rebar3_hex_http.erl
+++ b/src/rebar3_hex_http.erl
@@ -13,8 +13,6 @@
 -include("rebar3_hex.hrl").
 -include_lib("public_key/include/OTP-PUB-KEY.hrl").
 
--define(ENDPOINT, "/api").
-
 get(Path, Auth) ->
     case httpc:request(get, request(Path, Auth)
                       ,[{ssl, rebar_api:ssl_opts(rebar3_hex_config:api_url())}, {relaxed, true}]
@@ -94,19 +92,19 @@ pretty_print_status(Code) -> io_lib:format("HTTP status code: ~p", [Code]).
 %% Internal Functions
 
 request(Path, Auth) ->
-    {ec_cnv:to_list(rebar3_hex_config:api_url()) ++ ec_cnv:to_list(filename:join(?ENDPOINT, Path))
+    {ec_cnv:to_list(rebar3_hex_config:api_url()) ++ "/" ++ ec_cnv:to_list(Path)
     ,[{"authorization",  ec_cnv:to_list(Auth)}, {"user-agent", user_agent()}
      , {"Accept", "application/vnd.hex+erlang"}]}.
 
 map_request(Path, Auth, Body) ->
-    {ec_cnv:to_list(rebar3_hex_config:api_url()) ++ ec_cnv:to_list(filename:join(?ENDPOINT, Path))
+    {ec_cnv:to_list(rebar3_hex_config:api_url()) ++ "/" ++ ec_cnv:to_list(Path)
     ,[{"authorization",  ec_cnv:to_list(Auth)}, {"user-agent", user_agent()},
       {"Accept", "application/vnd.hex+erlang"}]
     ,"application/vnd.hex+erlang", term_to_binary(Body)}.
 
 
 file_request(Path, Auth, Body, ContentLength) ->
-    {ec_cnv:to_list(rebar3_hex_config:api_url()) ++ ec_cnv:to_list(filename:join(?ENDPOINT, Path))
+    {ec_cnv:to_list(rebar3_hex_config:api_url()) ++ "/" ++ ec_cnv:to_list(Path)
     ,[{"authorization", ec_cnv:to_list(Auth)}
      ,{"content-length", ContentLength}, {"user-agent", user_agent()},
       {"Accept", "application/vnd.hex+erlang"}] %%Erlang media type


### PR DESCRIPTION
When I use mix and rebar3 to connect with hex API they have inconsistent naming of api_url configuration setting. Default rebar3's api_url points to https://hex.pm while mix points to https://hex.pm/api
```
kuba.odias@mac:~/git/process_group$ mix hex.config api_url http://hex.pdmbuilds.proximetry.com/api
kuba.odias@mac:~/git/process_group$ rebar3 hex config api_url
api_url: http://hex.pdmbuilds.proximetry.com/api
```
Request with 'rebar3 hex'  fails with HTTP 404 Not Found
```
kuba.odias@mac:~/git/process_group$ DEBUG=1 rebar3 hex key list
===> Load global config file /Users/kuba.odias/.config/rebar3/rebar.config
===> Expanded command sequence to be run: []
===> Expanded command sequence to be run: [{hex,key}]
===> Uncaught error in rebar_core. Run with DEBUG=1 to see stacktrace or consult rebar3.crashdump
===> Uncaught error: {case_clause,{error,404}}
===> Stack trace to the error location:
[{rebar3_hex_key,do,1,
                 [{file,"/Users/kuba.odias/.cache/rebar3/plugins/rebar3_hex/src/rebar3_hex_key.erl"},
                  {line,43}]},
 {rebar_core,do,2,
             [{file,"/home/tristan/Devel/rebar3/_build/default/lib/rebar/src/rebar_core.erl"},
              {line,153}]},
 {rebar_prv_do,do_tasks,2,
               [{file,"/home/tristan/Devel/rebar3/_build/default/lib/rebar/src/rebar_prv_do.erl"},
                {line,68}]},
 {rebar_core,do,2,
             [{file,"/home/tristan/Devel/rebar3/_build/default/lib/rebar/src/rebar_core.erl"},
              {line,153}]},
 {rebar3,main,1,
         [{file,"/home/tristan/Devel/rebar3/_build/default/lib/rebar/src/rebar3.erl"},
          {line,66}]},
 {escript,run,2,[{file,"escript.erl"},{line,759}]},
 {escript,start,1,[{file,"escript.erl"},{line,277}]},
 {init,start_em,1,[]}]
===> When submitting a bug report, please include the output of `rebar3 report "your command"`
```

Changing api_url to URL without /api works ok
```
kuba.odias@mac:~/git/process_group$ mix hex.config api_url http://hex.pdmbuilds.proximetry.com
kuba.odias@mac:~/git/process_group$ rebar3 hex config api_url
api_url: http://hex.pdmbuilds.proximetry.com
kuba.odias@mac:~/git/process_group$ DEBUG=1 rebar3 hex key list
===> Load global config file /Users/kuba.odias/.config/rebar3/rebar.config
===> Expanded command sequence to be run: []
===> Expanded command sequence to be run: [{hex,key}]
api_key
```
However such setting of api_url is not correct for mix.