### PR TITLE
Improve error messages

### DIFF
--- a/src/rebar3_hex_config.erl
+++ b/src/rebar3_hex_config.erl
@@ -70,7 +70,8 @@ do(State) ->
 
 -spec format_error(any()) -> iolist().
 format_error(no_user) ->
-    "No user registered. See https://hex.pm/docs/rebar3_publish for instructions.";
+    ("No user registered. Either register or, if you have registered, "
+     "please auth. See https://hex.pm/docs/rebar3_publish for instructions.");
 format_error(Reason) ->
     io_lib:format("~p", [Reason]).
 

--- a/src/rebar3_hex_user.erl
+++ b/src/rebar3_hex_user.erl
@@ -140,11 +140,17 @@ create_user(Username, Email, Password) ->
         generate_key(Username, Password),
         ec_talk:say("You are required to confirm your email to access your account, "
                     "a confirmation email has been sent to ~s", [Email]);
-      {error, StatusCode, _} ->
-        ec_talk:say("Registration of user ~s failed (~p)", [Username, StatusCode]),
+      {error, StatusCode, Message} ->
+        case Message of
+          #{<<"message">> := Reason} ->
+            ec_talk:say("Registration of user ~s failed (~p, ~s)",
+                        [Username, StatusCode, Reason]);
+          _ ->
+            ec_talk:say("Registration of user ~s failed (~p)",
+                        [Username, StatusCode])
+        end,
         error
     end.
-
 
 generate_key(Username, Password) ->
     ec_talk:say("Generating API key..."),


### PR DESCRIPTION
Specifically

* when trying to publish to without a user registered or authed.
   - make sure that users are reminded you can register *or* auth
* when trying register a user with an invalid API key
   - print the reason so that you can more quickly see what is wrong