### PR TITLE
Get correct password on win32.

### DIFF
--- a/src/rebar3_hex_utils.erl
+++ b/src/rebar3_hex_utils.erl
@@ -118,11 +118,11 @@ prompt_win32_password(Prompt) ->
     receive
         {done, Parent, Ref} ->
             Parent ! {done, self(), Ref},
-            Spaces = lists:duplicate(size(Prompt) + 16, $ ),
+            Spaces = lists:duplicate(size(Prompt) + 24, $ ),
             io:fwrite(standard_error, "~ts\r~ts\r", [ClearLine, Spaces])
     after
         1 ->
-            Spaces = lists:duplicate(16, $ ),
+            Spaces = lists:duplicate(24, $ ),
             io:fwrite(standard_error, "~ts\r~ts~ts\r~ts", [ClearLine, Prompt, Spaces, Prompt]),
             prompt_win32_password(Prompt)
     end.


### PR DESCRIPTION
This changes the password routines on windows to ignore the newline on password entry.

In addition, this adds additional overwriting on the clear routines to both hide the ANSI escape code when it is ignored and to overprint pasted passwords less than 16 characters long with spaces.

There's still some edge cases with narrow terminals, but this allows for authentication and publishing to work on windows again.

This is an alternative to https://github.com/tsloughter/rebar3_hex/pull/90 that tries to solve a few more problems. It works for me on Windows 10, both with and without ANSI escape codes enabled in the terminal.
