### PR TITLE
Fix tests and declare OTP 18+ as required

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,8 @@
-{erl_opts, [debug_info]}.
+{erl_opts, [
+    debug_info,
+    {platform_define, "^19", 'POST_OTP_18'},
+    {platform_define, "^[2-9]", 'POST_OTP_18'}
+]}.
 
 {profiles, [
     {test, [

--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,5 @@
+{minimum_otp_vsn, "18"}.
+
 {erl_opts, [
     debug_info,
     {platform_define, "^19", 'POST_OTP_18'},

--- a/src/rebar3_hex_utils.erl
+++ b/src/rebar3_hex_utils.erl
@@ -25,7 +25,7 @@ pretty_print_errors(Errors) ->
         end,
     [],
   Errors),
-  binary:list_to_bin(lists:join(", ", L)).
+  binary:list_to_bin(join_lists(", ", L)).
     
 repo_opt() ->
     {repo, $r, "repo", string, "Repository to use for this command."}.
@@ -169,3 +169,12 @@ dir_files(Path) ->
         false ->
             [Path]
     end.
+
+-ifdef(POST_OTP_18).
+join_lists(Sep, List) -> lists:join(Sep, List).
+-else.
+join_lists(_Sep, []) -> [];
+join_lists(Sep, List) ->
+    [Last | AllButLast] = lists:reverse(List),
+    lists:foldl(fun (Elem,Acc) -> [Elem,Sep|Acc] end, [Last], AllButLast).
+-endif.

--- a/test/rebar3_hex_utils_SUITE.erl
+++ b/test/rebar3_hex_utils_SUITE.erl
@@ -64,8 +64,8 @@ repo(_Config) ->
     ?assertThrow({error, {rebar_hex_repos, {repo_not_found, <<"eh">>}}}, rebar3_hex_utils:repo(State4)).
 
 format_error_test(_Config) ->
-    Exp = "No configuration for repository foo found.",
-    ?assertEqual(Exp, rebar3_hex_utils:format_error({not_valid_repo, foo})).
+    Exp = <<"No configuration for repository foo found.">>,
+    ?assertEqual(Exp, iolist_to_binary(rebar3_hex_utils:format_error({not_valid_repo, foo}))).
 
 binarify_test(_Config) ->
     ?assertEqual(true, rebar3_hex_utils:binarify(true)),

--- a/test/support/hex_db.erl
+++ b/test/support/hex_db.erl
@@ -8,6 +8,8 @@
 
 -export([handle_call/3, handle_info/2, handle_cast/2, init/1]).
 
+-export([terminate/2]).
+
 % Client
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
@@ -41,3 +43,6 @@ handle_cast(_, State) ->
 
 handle_info(_, State) -> 
     {ok, State}. 
+
+terminate(_Reason, _State) ->
+    ok.

--- a/test/support/hex_db.erl
+++ b/test/support/hex_db.erl
@@ -8,7 +8,7 @@
 
 -export([handle_call/3, handle_info/2, handle_cast/2, init/1]).
 
--export([terminate/2]).
+-export([terminate/2, code_change/3]).
 
 % Client
 start_link() ->
@@ -46,3 +46,6 @@ handle_info(_, State) ->
 
 terminate(_Reason, _State) ->
     ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.


### PR DESCRIPTION
* **Fix noise in logs when running test cases in OTP 19 or older**
  * Related to an undefined `gen_server:terminate/2` callback
* **Fix compiler warning when building test cases in OTP 19 or older**
  * Related to an undefined `gen_server:code_change/3` callback
* **Fix broken test cases**
  * One because `lists:join/2` is missing (OTP 18)
  * Another due to expecting `io_lib:format` to always return strings
* **Declare OTP 18 as the oldest supported version**
  * Support for AES-GCM cipher only made it to `crypto` in OTP 18 - encrypting repo write keys crashes in OTP 17 (compilation fails in the first place - the fixes are simple but I didn't include them since they would serve no purpose.)
