### PR TITLE
User suite integration tests round 2

### DIFF
--- a/src/rebar3_hex_user.erl
+++ b/src/rebar3_hex_user.erl
@@ -202,7 +202,7 @@ generate_all_keys(Username, Password, LocalPassword, Repo, State) ->
     ReposPermissions = [#{<<"domain">> => <<"repositories">>}],
     {ok, ReposKey} = generate_key(RepoConfig1, ReposKeyName, ReposPermissions),
 
-    rebar_hex_repos:update_auth_config(#{RepoName => #{username => Username,
+    rebar3_hex_utils:update_auth_config(#{RepoName => #{username => Username,
                                                        write_key => WriteKeyEncrypted,
                                                        read_key => ReadKey,
                                                        repos_key => ReposKey}}, State),

--- a/test/rebar3_hex_integration_SUITE.erl
+++ b/test/rebar3_hex_integration_SUITE.erl
@@ -4,34 +4,40 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
--define(CONFIG, maps:merge(hex_core:default_config(), #{
+-define(REPO_CONFIG, maps:merge(hex_core:default_config(), #{
                              name        => <<"foo">>,
-                             repo        => <<"foo">>, 
+                             repo        => <<"foo">>,
                              api_url     => <<"http://127.0.0.1:3000">>,
                              repo_url    => <<"http://127.0.0.1:3000">>,
-                             repo_verify => false})).
+                             repo_verify => false,
+                             read_key                 => <<"123">>,
+                             repo_public_key          => <<0>>,
+                             repos_key                => <<"repos_key">>,
+                             username                 => <<"mr_pockets">>,
+                             write_key               => {<<0>>,{<<0>>}}
+                            })).
 
 %%%%%%%%%%%%%%%%%%
 %%%  CT hooks  %%%
 %%%%%%%%%%%%%%%%%%
 
 all() ->
-[sanity_check, register_user, register_existing_user].
+    [sanity_check, register_user, register_existing_user, auth_test, whoami_test, deauth_test].
 
-init_per_suite(Config) -> 
-    meck:new([ec_talk, rebar3_hex_utils], [passthrough, no_link]),
+init_per_suite(Config) ->
+    meck:new([ec_talk, rebar3_hex_utils], [passthrough, no_link, unstick]),
     Config.
 
 end_per_suite(Config) ->
-  meck:unload([ec_talk, rebar3_hex_utils]),
-  Config.
+    meck:unload([ec_talk, rebar3_hex_utils]),
+    Config.
 
-init_per_testcase(_Tc, Cfg) -> 
+init_per_testcase(_Tc, Cfg) ->
     {ok, StorePid} = hex_db:start_link(),
     {ok, MockPid} = elli:start_link([{callback, hex_api_callback}, {port, 3000}]),
     [{hex_store, StorePid}, {hex_mock_server, MockPid} | Cfg].
 
-end_per_testcase(_Tc, Config) -> 
+end_per_testcase(_Tc, Config) ->
     StorePid = ?config(hex_store, Config),
     MockPid = ?config(hex_mock_server, Config),
     ok = hex_db:stop(StorePid),
@@ -43,73 +49,188 @@ end_per_testcase(_Tc, Config) ->
 %%% Test Cases %%%
 %%%%%%%%%%%%%%%%%%
 
-sanity_check(_Config) -> 
+sanity_check(_Config) ->
     begin
-      User = <<"mr_pockets">>,
-      Pass = <<"special_shoes">>,
-      Email = <<"foo@bar.baz">>,
-      {ok, {201, _Headers, Res}} = create_user(User, Pass, Email),
-      ?assertEqual(User, maps:get(<<"username">>, Res)),
-      ?assertEqual(Email, maps:get(<<"email">>, Res)),
-      ?assert(maps:is_key(<<"inserted_at">>, Res)),
-      ?assert(maps:is_key(<<"updated_at">>, Res))
+        User = <<"mr_pockets">>,
+        Pass = <<"special_shoes">>,
+        Email = <<"foo@bar.baz">>,
+        Repo = repo_config(),
+        {ok, {201, _Headers, Res}} = create_user(User, Pass, Email, Repo),
+        ?assertEqual(User, maps:get(<<"username">>, Res)),
+        ?assertEqual(Email, maps:get(<<"email">>, Res)),
+        ?assert(maps:is_key(<<"inserted_at">>, Res)),
+        ?assert(maps:is_key(<<"updated_at">>, Res))
     end.
 
-
 register_user(_Config) ->
-     begin
-         mock_register_io(<<"mr_pockets">>, <<"foo@bar.org">>, <<"special_shoes">>),
-         State = rebar_state:new(), 
-         Exp = {ok, State},
-         ?assertMatch(Exp, rebar3_hex_user:hex_register(config(), State))
-     end.
+    begin
+        Repo = repo_config(),
+        setup_mocks_for(register, {<<"mr_pockets">>, <<"foo@bar.baz">>, <<"special_shoes">>, Repo}),
+        State = mock_command("register", Repo),
+        ?assertMatch({ok, State}, rebar3_hex_user:do(State))
+    end.
 
 register_existing_user(_Config) ->
-     begin
-         State = rebar_state:new(),
-         User = <<"mr_pockets">>,
-         Pass = <<"special_shoes1">>,
-         Email = <<"foo@bar.org">>,
-         create_user(User, Pass, Email),
-         mock_register_io(<<"mr_pockets1">>, Email, Pass),
-         ExpReason1 = <<"email already in use">>,
-         ExpErr1 = {error, {rebar3_hex_user, {registration_failure, ExpReason1}}},
-         ?assertMatch(ExpErr1, rebar3_hex_user:hex_register(config(), State))
-     end.
+    begin
+        User = <<"mr_pockets">>,
+        Pass = <<"special_shoes1">>,
+        Email = <<"foo@bar.baz">>,
+        Repo = repo_config(),
+        create_user(User, Pass, Email, Repo),
+        setup_mocks_for(register_existing, {<<"mr_pockets1">>, Email, Pass, Repo}),
+        ExpReason1 = <<"email already in use">>,
+        ExpErr1 = {error, {rebar3_hex_user, {registration_failure, ExpReason1}}},
+        State = mock_command("register", Repo),
+        ?assertMatch(ExpErr1, rebar3_hex_user:do(State))
+    end.
 
+auth_test(_Config) ->
+    begin
+        User = <<"mr_pockets">>,
+        Pass = <<"special_shoes1">>,
+        Email = <<"foo@bar.baz">>,
+        Repo = repo_config(),
+        create_user(User, Pass, Email, Repo),
+        setup_mocks_for(first_auth, {User, Email, Pass, Repo}),
+        AuthState = mock_command("auth", Repo),
+        ?assertMatch({ok, AuthState}, rebar3_hex_user:do(AuthState))
+    end.
+
+whoami_test(_Config) ->
+    begin
+        Repo = repo_config(),
+        setup_mocks_for(whoami, {<<"mr_pockets">>, <<"foo@bar.baz">>, <<"special_shoes">>, Repo}),
+        WhoamiState = mock_command("whoami", Repo),
+        ?assertMatch({ok, WhoamiState}, rebar3_hex_user:do(WhoamiState))
+    end.
+
+deauth_test(_Config) ->
+    begin
+        Repo = repo_config(),
+        setup_mocks_for(deauth, {<<"mr_pockets">>, <<"foo@bar.baz">>, <<"special_shoes">>, Repo}),
+        DeauthState = mock_command("deauth", Repo),
+        ?assertMatch(ok, rebar3_hex_user:do(DeauthState))
+    end.
 
 %%%%%%%%%%%%%%%%%%
 %%%  Helpers   %%%
 %%%%%%%%%%%%%%%%%%
 
-config() -> 
-    ?CONFIG.
+mock_command(Command, Repo) ->
+    State0 = rebar_state:new([{command_parsed_args, []}, {resources, []},
+                              {hex, [{repos, [Repo]}]}]),
+    State1 = rebar_state:add_resource(State0, {pkg, rebar_pkg_resource}),
+    State2 = rebar_state:create_resources([{pkg, rebar_pkg_resource}], State1),
+    rebar_state:command_args(State2, [Command]).
 
-create_user(User, Pass, Email) -> 
-    hex_api_user:create(config(), User, Pass, Email).
+repo_config() ->
+    ?REPO_CONFIG.
 
-mock_register_io(Username, Email, Password) -> 
-    ExpectedInfo = "By registering an account on Hex.pm you accept all our"
-         ++ " policies and terms of service found at https://hex.pm/policies\n", 
+create_user(User, Pass, Email, Repo) ->
+    hex_api_user:create(Repo, User, Pass, Email).
+
+setup_mocks_for(first_auth, {Username, Email, Password, Repo}) ->
+    AuthInfo =  "You have authenticated on Hex using your account password. "
+    ++ "However, Hex requires you to have a local password that applies "
+    ++ "only to this machine for security purposes. Please enter it.",
+    %  #{read_key => <<"secret">>,repos_key => <<"secret">>,
+    %   username => <<"mr_pockets">>,
+    meck:expect(rebar3_hex_utils, update_auth_config, fun(Cfg, State) ->
+                                                              Rname = maps:get(name, Repo),
+                                                              Skey = maps:get(repos_key, Repo),
+                                                              [Rname] = maps:keys(Cfg),
+                                                              #{repos_key := Skey, username := Username} = _ = maps:get(Rname, Cfg),
+                                                              {ok, State} end),
     meck:expect(rebar3_hex_utils, get_password, fun(_Arg) -> Password end),
-    meck:expect(ec_talk, say, fun(Arg) -> 
-        case Arg of 
-            ExpectedInfo -> 
-                ok;
-            "Registering..." ->
-                ok
-        end        
-    end),
+    meck:expect(ec_talk, say, fun(Arg) ->
+                                      case Arg of
+                                          "Generating all keys..." ->
+                                              ok;
+                                          AuthInfo ->
+                                              ok
+                                      end
+                              end),
     meck:expect(ec_talk, ask_default, fun(Prompt, string, "") ->
-        case Prompt of 
-            "Email:" ->
-                binary_to_list(Email);
-            "Username:" ->
-                binary_to_list(Username)
-        end
-    end).
+                                              case Prompt of
+                                                  "Email:" ->
+                                                      binary_to_list(Email);
+                                                  "Username:" ->
+                                                      binary_to_list(Username)
+                                              end
+                                      end);
+
+setup_mocks_for(whoami, {Username, Email, _Password, _Repo}) ->
+    meck:expect(ec_talk, say, fun(Str, Args) ->
+                                      case {Str, Args} of
+                                          {"~ts (~ts)", [<<Username/binary>>, <<Email/binary>>]} ->
+                                              ok
+                                      end
+                              end);
+
+setup_mocks_for(deauth, {_Username, _Email, _Password, _Repo}) ->
+    meck:expect(ec_talk, say, fun(Arg) ->
+                                      case Arg of
+                                          "Currently not implemented." ->
+                                              ok
+                                      end
+                              end);
+
+setup_mocks_for(register, {Username, Email, Password, Repo}) ->
+    ExpectedInfo = "By registering an account on Hex.pm you accept all our"
+    ++ " policies and terms of service found at https://hex.pm/policies\n",
+    meck:expect(rebar3_hex_utils, update_auth_config, fun(_Cfg, State) -> {ok, State} end),
+    meck:expect(rebar3_hex_utils, get_password, fun(_Arg) -> Password end),
+    ReqInfo = "You are required to confirm your email to access your account, "
+    ++ "a confirmation email has been sent to ~s",
+    TokenInfo = "Then run `rebar3 hex auth -r ~ts` to create and configure api tokens locally.",
+    RepoName = maps:get(name, Repo),
+    meck:expect(ec_talk, say, fun(Str, Args) ->
+                                      case {Str, Args} of
+                                          {TokenInfo, [RepoName]} ->
+                                              ok;
+                                          {ReqInfo, [Email]} ->
+                                              ok
+                                      end
+                              end),
+    meck:expect(ec_talk, say, fun(Arg) ->
+                                      case Arg of
+                                          ExpectedInfo ->
+                                              ok;
+                                          "Registering..." ->
+                                              ok
+                                      end
+                              end),
+    meck:expect(ec_talk, ask_default, fun(Prompt, string, "") ->
+                                              case Prompt of
+                                                  "Email:" ->
+                                                      binary_to_list(Email);
+                                                  "Username:" ->
+                                                      binary_to_list(Username)
+                                              end
+                                      end);
+
+setup_mocks_for(register_existing, {Username, Email, Password, _Repo}) ->
+    ExpectedInfo = "By registering an account on Hex.pm you accept all our"
+    ++ " policies and terms of service found at https://hex.pm/policies\n",
+    meck:expect(rebar3_hex_utils, get_password, fun(_Arg) -> Password end),
+    meck:expect(ec_talk, say, fun(Arg) ->
+                                      case Arg of
+                                          ExpectedInfo ->
+                                              ok;
+                                          "Registering..." ->
+                                              ok
+                                      end
+                              end),
+    meck:expect(ec_talk, ask_default, fun(Prompt, string, "") ->
+                                              case Prompt of
+                                                  "Email:" ->
+                                                      binary_to_list(Email);
+                                                  "Username:" ->
+                                                      binary_to_list(Username)
+                                              end
+                                      end).
 
 reset_mocks(Modules) ->
     meck:reset(Modules),
     [meck:delete(Module, Fun, Arity, false)
-    || {Module, Fun, Arity} <- meck:expects(Modules, true)].
+     || {Module, Fun, Arity} <- meck:expects(Modules, true)].

--- a/test/rebar3_hex_user_SUITE.erl
+++ b/test/rebar3_hex_user_SUITE.erl
@@ -5,7 +5,19 @@
 -include_lib("eunit/include/eunit.hrl").
 
 all() ->
-    [encrypt_decrypt_write_key].
+    [init_test, encrypt_decrypt_write_key].
+
+init_test(_Config) ->
+    {ok, State} = rebar3_hex_user:init(rebar_state:new()),
+    Exp = [{provider,user,rebar3_hex_user,
+                      {[],[]},
+                      true,[],[],"Hex user tasks","rebar3 hex user <command>",
+                      [{repo,114,"repo",string,
+                             "Repository to use for this command."}],
+                      [default],
+                      hex}],
+    ?assertMatch(Exp, rebar_state:providers(State)),
+    ?assertError(function_clause, rebar3_hex_user:init({})).
 
 encrypt_decrypt_write_key(_Config) ->
     WriteKey = <<"abc1234">>,
@@ -16,6 +28,6 @@ encrypt_decrypt_write_key(_Config) ->
     WriteKeyEncrypted = rebar3_hex_user:encrypt_write_key(Username, LocalPassword, WriteKey),
 
     ?assertThrow({error,{rebar3_hex_user,bad_local_password}},
-                 rebar3_hex_user:decrypt_write_key(Username, <<"wrong password">>, WriteKeyEncrypted)),
+                  rebar3_hex_user:decrypt_write_key(Username, <<"wrong password">>, WriteKeyEncrypted)),
 
     ?assertEqual(WriteKey, rebar3_hex_user:decrypt_write_key(Username, LocalPassword, WriteKeyEncrypted)).


### PR DESCRIPTION
  - reorganized mock and mock functions to be more explicit and
    understandable
  - wrote tests for auth, whoami, deauth
  - changed register and register_existing to folow suite for new
    command tests (i.e, go through rebar3_hex_user:do/1)
  - moved generate_all_keys/5, encrypt_write_key/2 and
        decrypt_write_key/{2,3} to rebar3_hex_utils