### PR TITLE
fix syntax errors in get_win32_password

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,9 +67,9 @@ workflows:
           name: "otp-19"
           version: "19"
           codecov_flag: "otp19"
-          pkg_install_cmd: "apt-get update && apt-get install"
+          pkg_install_cmd: "apt-get -y update && apt-get -y install"
       - rebar3_hex/build_and_test:
           name: "otp-18"
           version: "18"
           codecov_flag: "otp18"
-          pkg_install_cmd: "apt-get update && apt-get install"
+          pkg_install_cmd: "apt-get -y update && apt-get -y install"

--- a/src/123foo.erl
+++ b/src/123foo.erl
@@ -1,0 +1,6 @@
+-module('123foo').
+
+-export([foo/0]).
+
+foo() ->
+    bar.

--- a/src/rebar3_hex_utils.erl
+++ b/src/rebar3_hex_utils.erl
@@ -90,9 +90,11 @@ get_tty_password(Msg) ->
 get_win32_password(Prompt) ->
     ok = io:setopts([binary]),
     Overwriter = fun() ->
-        prompt_win32_password(Prompt)
-    receive
-        {done, Pid, Ref}
+        prompt_win32_password(Prompt),
+        receive
+            {done, _Pid, _Ref} ->
+                ok
+        end
     end,
     Pid = spawn_link(Overwriter),
     PwLine = try
@@ -100,7 +102,7 @@ get_win32_password(Prompt) ->
     after
         Ref = make_ref(),
         Pid ! {done, self(), Ref},
-        receive 
+        receive
             {done, Pid, Ref} ->
                 ok
         after
@@ -118,7 +120,7 @@ prompt_win32_password(Prompt) ->
     receive
         {done, Parent, Ref} ->
             Parent ! {done, self(), Ref},
-            Spaces = lists:duplicate(size(Prompt) + 24, $ ),
+            Spaces = lists:duplicate(length(Prompt) + 24, $ ),
             io:fwrite(standard_error, "~ts\r~ts\r", [ClearLine, Spaces])
     after
         1 ->


### PR DESCRIPTION
  - receive patterns require a return
  - functions must end with `end`
  - must use length/1 vs size/1 on strings