### PR TITLE
Fix win32 password entry.

### DIFF
--- a/src/rebar3_hex_utils.erl
+++ b/src/rebar3_hex_utils.erl
@@ -126,7 +126,7 @@ prompt_win32_password(Prompt) ->
     receive
         {done, Parent, Ref} ->
             Parent ! {done, self(), Ref},
-            Spaces = lists:duplicate(length(Prompt) + 24, $ ),
+            Spaces = lists:duplicate(size(Prompt) + 24, $ ),
             io:fwrite(standard_error, "~ts\r~ts\r", [ClearLine, Spaces])
     after
         1 ->

--- a/src/rebar3_hex_utils.erl
+++ b/src/rebar3_hex_utils.erl
@@ -126,7 +126,7 @@ prompt_win32_password(Prompt) ->
     receive
         {done, Parent, Ref} ->
             Parent ! {done, self(), Ref},
-            Spaces = lists:duplicate(size(Prompt) + 24, $ ),
+            Spaces = lists:duplicate(byte_size(Prompt) + 24, $ ),
             io:fwrite(standard_error, "~ts\r~ts\r", [ClearLine, Spaces])
     after
         1 ->


### PR DESCRIPTION
As `Prompt` is a binary, this patch prevents a run time error on
password blanking. This appears to be the only change needed to get the plugin working on windows again, after the original botched merge and subsequent emergency fix.