### PR TITLE
Return an error tuple when whoami invokved in unauthed repo

### DIFF
--- a/src/rebar3_hex_user.erl
+++ b/src/rebar3_hex_user.erl
@@ -94,7 +94,7 @@ hex_register(Repo, State) ->
 whoami(Repo, State) ->
     case maps:get(read_key, Repo, undefined) of
         undefined ->
-            ec_talk:say("Not authenticated as any user currently for this repository");
+            {error, "Not authenticated as any user currently for this repository"};
         ReadKey ->
             case hex_api_user:me(Repo#{api_key => ReadKey}) of
                 {ok, {200, _Headers, #{<<"username">> := Username,

--- a/test/rebar3_hex_integration_SUITE.erl
+++ b/test/rebar3_hex_integration_SUITE.erl
@@ -294,7 +294,8 @@ whoami_not_authed_test(_Config) ->
                                   end),
         catch ec_talk:say(Str),
         WhoamiState = test_utils:mock_command("whoami", Repo),
-        ?assertMatch(ok, rebar3_hex_user:do(WhoamiState)),
+        ExpErr = {error,"Not authenticated as any user currently for this repository"},
+        ?assertMatch(ExpErr, rebar3_hex_user:do(WhoamiState)),
         ?assert(meck:validate(ec_talk))
     end.
 


### PR DESCRIPTION
We were giving the error message with ec_talk and returning `ok` implicit, this would result in a rebar3 crash dump. 