### PR TITLE
Recurse map(s) in pretty_print_errors

### DIFF
--- a/src/rebar3_hex_utils.erl
+++ b/src/rebar3_hex_utils.erl
@@ -28,7 +28,12 @@ update_auth_config(Config, State) ->
 
 pretty_print_errors(Errors) ->
   L =  maps:fold(fun(K,V,Acc) ->
-                Acc ++ [<<K/binary, " ", V/binary>>]
+            case is_map(V) of
+                true ->
+                   Acc ++ [pretty_print_errors(V)];
+                false ->
+                    Acc ++ [<<K/binary, " ", V/binary>>]
+            end
         end,
     [],
   Errors),

--- a/test/rebar3_hex_utils_SUITE.erl
+++ b/test/rebar3_hex_utils_SUITE.erl
@@ -6,7 +6,12 @@
 
 all() ->
     [pretty_print_status,
+     pretty_print_errors,
     repo_opt, repo, format_error_test, binarify_test, expand_paths_test].
+
+pretty_print_errors(_Config) ->
+    Errors = #{<<"emails">>=>#{<<"email">>=><<"already in use">>}},
+    ?assertEqual(<<"email already in use">>, rebar3_hex_utils:pretty_print_errors(Errors)).
 
 pretty_print_status(_Config) ->
     ?assertEqual("Authentication failed (401)", rebar3_hex_utils:pretty_print_status(401)),


### PR DESCRIPTION
Closes #77

 This PR takes care of a bug where by certain registration states would cause a rebar crash because we were not handling deeply nested errors here. In doing so I believe we meet all criteria for closing  #77.

 - We print `No write key found for user. Be sure to authenticate first with: rebar3 hex user auth` if not authenticated
 - We print `Registration of user failed: email already in use` 
 - We print ` Registration of user failed: username has already been taken`