### PR TITLE
Make r switch mandatory when non-default repos are detected for state changing ops

### DIFF
--- a/src/rebar3_hex_cut.erl
+++ b/src/rebar3_hex_cut.erl
@@ -35,7 +35,14 @@ init(State) ->
 
 -spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
 do(State) ->
-    Repo = rebar3_hex_utils:repo(State),
+    case rebar3_hex_utils:repo(State) of
+        {ok, Repo} ->
+            handle_command(State, Repo);
+        {error, Reason} ->
+            ?PRV_ERROR(Reason)
+    end.
+
+handle_command(State, Repo) ->
     case maps:get(write_key, Repo, undefined) of
         undefined ->
             ?PRV_ERROR({no_write_key, maps:get(name, Repo)});

--- a/src/rebar3_hex_owner.erl
+++ b/src/rebar3_hex_owner.erl
@@ -29,8 +29,14 @@ init(State) ->
 
 -spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
 do(State) ->
-    Repo = rebar3_hex_utils:repo(State),
+    case rebar3_hex_utils:repo(State) of
+        {ok, Repo} ->
+            handle_command(State, Repo);
+        {error, Reason} ->
+            ?PRV_ERROR(Reason)
+    end.
 
+handle_command(State, Repo) ->
     case rebar_state:command_args(State) of
         ["add", Package, UsernameOrEmail] ->
             add(Repo, Package, UsernameOrEmail, State),

--- a/src/rebar3_hex_retire.erl
+++ b/src/rebar3_hex_retire.erl
@@ -38,8 +38,14 @@ init(State) ->
 
 -spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
 do(State) ->
-    Repo = rebar3_hex_utils:repo(State),
+    case rebar3_hex_utils:repo(State) of
+        {ok, Repo} ->
+            handle_command(State, Repo);
+        {error, Reason} ->
+            ?PRV_ERROR(Reason)
+    end.
 
+handle_command(State, Repo) ->
     {Args, _} = rebar_state:command_parsed_args(State),
     Name = get_required(pkg, Args),
     PkgName = rebar_utils:to_binary(Name),

--- a/src/rebar3_hex_revert.erl
+++ b/src/rebar3_hex_revert.erl
@@ -36,8 +36,14 @@ init(State) ->
 
 -spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
 do(State) ->
-    Repo = rebar3_hex_utils:repo(State),
+    case rebar3_hex_utils:repo(State) of
+        {ok, Repo} ->
+            handle_command(State, Repo);
+        {error, Reason} ->
+            ?PRV_ERROR(Reason)
+    end.
 
+handle_command(State, Repo) ->
     {Args, _} = rebar_state:command_parsed_args(State),
     case proplists:get_value(pkg, Args, undefined) of
         undefined ->

--- a/test/rebar3_hex_utils_SUITE.erl
+++ b/test/rebar3_hex_utils_SUITE.erl
@@ -54,11 +54,11 @@ repo(_Config) ->
                                 }
                     ]
                 },
+    _Resource = rebar_resource_v2:new(pkg, rebar_pkg_resource, PkgResConfig),
     State0 = rebar_state:new([{resources, []},
                              {command_parsed_args, []}]),
-    _Resource = rebar_resource_v2:new(pkg, rebar_pkg_resource, PkgResConfig),
     State1 = rebar_state:add_resource(State0, {pkg, rebar_pkg_resource}),
-    Repo = rebar3_hex_utils:repo(State1),
+    {ok, Repo} = rebar3_hex_utils:repo(State1),
     true = is_map(Repo),
     State2 = rebar_state:new([{resources, []},
                              {command_parsed_args, {[{repo,"eh"}],[]}}
@@ -66,7 +66,7 @@ repo(_Config) ->
     State3 = rebar_state:command_parsed_args(State2, {[{repo,"eh"}],[]}),
     _Resource1 = rebar_resource_v2:new(pkg, rebar_pkg_resource, PkgResConfig),
     State4 = rebar_state:add_resource(State3, {pkg, rebar_pkg_resource}),
-    ?assertThrow({error, {rebar_hex_repos, {repo_not_found, <<"eh">>}}}, rebar3_hex_utils:repo(State4)).
+    ?assertMatch({error,{not_valid_repo,"eh"}}, rebar3_hex_utils:repo(State4)).
 
 format_error_test(_Config) ->
     Exp = <<"No configuration for repository foo found.">>,

--- a/test/support/test_utils.erl
+++ b/test/support/test_utils.erl
@@ -34,8 +34,10 @@ mock_command(Command, Repo, State0) when is_tuple(Command) ->
     State1 = rebar_state:add_resource(State0, {pkg, rebar_pkg_resource}),
     State2 = rebar_state:create_resources([{pkg, rebar_pkg_resource}], State1),
     State3 = rebar_state:set(State2, hex, {repos,[Repo]}),
+    Resources = rebar_state:resources(State3),
+    #{repos := Repos} = rebar_resource_v2:find_resource_state(pkg, Resources),
     rebar_state:command_parsed_args(State3, Command);
-mock_command(Command, _Repo, State0) when is_list(Command) ->
+mock_command(Command, Repo, State0) when is_list(Command) ->
     State1 = rebar_state:add_resource(State0, {pkg, rebar_pkg_resource}),
     State2 = rebar_state:create_resources([{pkg, rebar_pkg_resource}], State1),
     rebar_state:command_args(State2, [Command]).


### PR DESCRIPTION
This PR aims to provide a consistent API when deciding what commands require a repo argument and more specifically when.

Things in this PR not directly related to the above:

    - move search result functions back into rebar3_hex_search, they never belonged in the utils module.
    - added maybe_throws/2 helper on utils module for handling function that maybe throw (specifically for breaking out of recursive functions). 

To recap on the API part here are the rules for when a repo argument is required going forward:

# Cut
 - **cut** requires a repo arg if non-defaults exist

# Docs
 - **docs** requires a repo arg if non-defaults exist

# Key
 - **list** does not require a repo arg, optionally can take one, otherwise aggregates results
 - **remove** requires a repo arg if non-defaults exist

# Owner
 - **add** requires a repo arg if non-defaults exist
 - **remove** requires a repo arg if non-defaults exist
 - **list** does not require a repo arg, can optionally take one, otherwise aggregates results

# Publish
 - **publish** requires a repo a arg if non-defaults exist

# Repo 
 - **generate** always requires a repo arg
 - **auth** - always requires a repo arg

# Retire
 - **retire** requires a repo arg if non-defaults exist

# Revert
 - **revert** requires a repo arg if non-defaults exist

# User
 - **register** requires a repo arg if non-defaults exist
 - **auth** requires a repo arg if non-defaults exist
 -  **deauth** requires a repo arg if non-defaults exist
 - **reset_password** requires a repo arg if non-defaults exist
 - **whoami** does not require a repo arg, can optionally take one, otherwise aggregates results

# Search
 - **search** does not require a repo arg, can optionally take one, otherwise aggregates results