### PR TITLE
Fix bug in rebar3_hex_search private function sort_by_downloads/1

### DIFF
--- a/src/rebar3_hex_search.erl
+++ b/src/rebar3_hex_search.erl
@@ -76,11 +76,12 @@ truncate_description(Description) ->
     end.
 
 sort_by_downloads(Packages) ->
+    {Unused, Popular} = lists:partition(fun(P) -> maps:get(<<"downloads">>, P) == #{} end, Packages),
     lists:sort(fun(#{<<"downloads">> := #{<<"all">> := A}},
                    #{<<"downloads">> := #{<<"all">> := B}}) ->
                        A > B
                end,
-               Packages).
+               Popular) ++ Unused.
 
 latest_stable(Releases) ->
     case gather_stable_releases(Releases) of


### PR DESCRIPTION
 Sort_by_downloads/1 did not take into account packages that have not
 been downloaded at all and would fail with a function clause error on such cases.