### PR TITLE
Implement key commands

### DIFF
--- a/src/rebar3_hex_client.erl
+++ b/src/rebar3_hex_client.erl
@@ -1,0 +1,51 @@
+-module(rebar3_hex_client).
+
+-export([key_add/3, key_get/2, key_delete/2, key_delete_all/1, key_list/1]).
+
+-include("rebar3_hex.hrl").
+
+key_add(HexConfig, <<KeyName/binary>>, Perms) ->
+    Res = hex_api_key:add(HexConfig, KeyName, Perms),
+    response(Res);
+key_add(HexConfig, KeyName, Perms) ->
+    key_add(HexConfig, to_binary(KeyName), Perms).
+
+key_get(HexConfig, <<KeyName/binary>>) ->
+    Res = hex_api_key:get(HexConfig, KeyName),
+    response(Res);
+key_get(HexConfig, KeyName) ->
+    key_get(HexConfig, to_binary(KeyName)).
+
+key_list(HexConfig) ->
+    Res = hex_api_key:list(HexConfig),
+    response(Res).
+
+key_delete(HexConfig, <<KeyName/binary>>) ->
+    Res = hex_api_key:delete(HexConfig, KeyName),
+    response(Res);
+key_delete(HexConfig, KeyName) ->
+    key_delete(HexConfig, to_binary(KeyName)).
+
+key_delete_all(HexConfig) ->
+    Res = hex_api_key:delete_all(HexConfig),
+    response(Res).
+
+response({ok, {200, _Headers, Res}}) ->
+    {success, Res};
+response({ok, {201, _Headers, Res}}) ->
+    {created, Res};
+response({ok, {204, _Headers, Res}}) ->
+    {success, Res};
+response({ok, {401, _Headers, Res}}) ->
+    {unauthorized, Res};
+response({ok, {404, _Headers, Res}}) ->
+    {not_found, Res};
+response({ok, {422, _Headers, #{<<"message">> := <<"Validation error(s)">>} = Res}}) ->
+    {validation_errors, Res};
+response({ok, {422, _Headers, Res}}) ->
+    {unprocessable, Res};
+response({_, _} = Unknown) ->
+    Unknown.
+
+to_binary(Subject) ->
+    rebar_utils:to_binary(Subject).

--- a/src/rebar3_hex_key.erl
+++ b/src/rebar3_hex_key.erl
@@ -18,10 +18,16 @@ init(State) ->
                                  {namespace, hex},
                                  {bare, true},
                                  {deps, ?DEPS},
-                                 {example, "rebar3 hex key [list | remove <key>]"},
+                                 {example, "rebar3 hex key [generate <key> | list | revoke <key> | revoke --all]"},
                                  {short_desc, "Remove or list API keys associated with your account"},
                                  {desc, ""},
-                                 {opts, []}]),
+                                 {opts, [
+                                         {all, $a, "all", boolean, "all."},
+                                         {keyname, $k, "key-name", string, "key-name"},
+                                         {permission, $p, "permission", list, "perms."},
+                                         rebar3_hex_utils:repo_opt()
+                                        ]
+                                 }]),
     State1 = rebar_state:add_provider(State, Provider),
     {ok, State1}.
 
@@ -29,17 +35,123 @@ init(State) ->
 %-spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
 -spec do(rebar_state:t()) -> {'error',{'rebar3_hex_key','bad_command' | 'not_implemented'}}.
 do(State) ->
+    case rebar3_hex_utils:repo(State) of
+        {ok, Repo} ->
+            handle_command(State, Repo);
+        {error, Reason} ->
+            ?PRV_ERROR(Reason)
+    end.
+
+handle_command(State, Repo) ->
     case rebar_state:command_args(State) of
-        ["remove", _KeyName] ->
-            ?PRV_ERROR(not_implemented);
+        ["generate"| _ ] ->
+             {ok, Config} = rebar3_hex_utils:hex_config_write(Repo),
+             {"generate", Params} = rebar3_hex_utils:task_args(State),
+            generate(State, Config, Params);
+        ["fetch", KeyName] ->
+             {ok, Config} = rebar3_hex_utils:hex_config_read(Repo),
+            fetch(State, Config, KeyName);
+        ["revoke", "--all"] ->
+            {ok, Config} = rebar3_hex_utils:hex_config_write(Repo),
+            revoke_all(State, Config);
+        ["revoke", KeyName] ->
+             {ok, Config} = rebar3_hex_utils:hex_config_write(Repo),
+            revoke(State, Config, KeyName);
         ["list"] ->
-            ?PRV_ERROR(not_implemented);
+			 {ok, Config} = rebar3_hex_utils:hex_config_read(Repo),
+            list(State, Config);
         _ ->
             ?PRV_ERROR(bad_command)
     end.
 
+generate(State, HexConfig, Params) ->
+    Perms = gather_permissions(proplists:get_all_values(permission, Params)),
+    KeyName =  proplists:get_value(keyname, Params, undefined),
+    case rebar3_hex_client:key_add(HexConfig, KeyName, Perms) of
+        {created, _Res} ->
+            ec_talk:say("Key successfully created", []),
+            {ok, State};
+        Error ->
+            ?PRV_ERROR({generate, Error})
+    end.
+
+fetch(State, HexConfig, KeyName) ->
+    case rebar3_hex_client:key_get(HexConfig, KeyName) of
+        {success, Res} ->
+            ok = print_key_details(Res),
+            {ok, State};
+        Error ->
+            ?PRV_ERROR({fetch, Error})
+    end.
+
+revoke(State, HexConfig, KeyName) ->
+    case rebar3_hex_client:key_delete(HexConfig, KeyName) of
+        {success, _Res} ->
+             ec_talk:say("Key successfully revoked", []),
+            {ok, State};
+        Error ->
+            ?PRV_ERROR({revoke, Error})
+    end.
+
+revoke_all(State, HexConfig) ->
+    case rebar3_hex_client:key_delete_all(HexConfig) of
+        {success, _Res} ->
+            ec_talk:say("All keys successfully revoked", []),
+            {ok, State};
+        Error ->
+            ?PRV_ERROR({revoke_all, Error})
+    end.
+
+list(State, HexConfig) ->
+    case rebar3_hex_client:key_list(HexConfig) of
+        {success, Res} ->
+            ok = print_results(Res),
+            {ok, State};
+        Error ->
+            ?PRV_ERROR({list, Error})
+    end.
+
+gather_permissions([]) ->
+    [];
+gather_permissions(Perms) ->
+    lists:foldl(fun(Name, Acc) ->
+                [Domain, Resource] = binary:split(rebar_utils:to_binary(Name), <<":">>),
+                [#{<<"domain">> => Domain, <<"resource">> => Resource}] ++ Acc
+                end, [], Perms).
+
+print_results(Res) ->
+    Header = ["Name", "Created"],
+    Rows = lists:map(fun(#{<<"name">> := Name, <<"inserted_at">> := Created}) ->
+                                [binary_to_list(Name), binary_to_list(Created)]
+                     end, Res),
+    ok = rebar3_hex_results:print_table([Header] ++ Rows),
+    ok.
+print_key_details(#{<<"name">> := Name,
+                    <<"inserted_at">> := Created,
+                    <<"updated_at">> := Updated,
+                    <<"last_use">> := #{
+                        <<"ip">> := Addr,
+                        <<"used_at">> := Used,
+                        <<"user_agent">> := _Agent
+                       }
+                   }
+                 ) ->
+    Header = ["Name", "Created", "Updated", "LastUsed", "LastUsedBy"],
+    Row = [binary_to_list(Name),
+           binary_to_list(Created),
+           binary_to_list(Updated),
+           binary_to_list(Used),
+           binary_to_list(Addr)],
+    ok = rebar3_hex_results:print_table([Header] ++ [Row]),
+    ok.
+
 -spec format_error(any()) -> iolist().
-format_error(not_implemented) ->
-    "Not implemented";
+format_error({list, {unauthorized, _Res}}) ->
+    "Not authorized";
+format_error({revoke, {not_found, _Res}}) ->
+    "Key not found";
+format_error({generate, {validation_errors, #{<<"errors">> := Errors, <<"message">> := Message}}}) ->
+    ErrorString = rebar3_hex_results:errors_to_string(Errors),
+    io_lib:format("~ts~n\t~ts", [Message, ErrorString]);
 format_error(bad_command) ->
-    "Unknown command. Command must be remove or list.".
+    "Unknown command. Command must be fetch, generate, list, or revoke".

--- a/src/rebar3_hex_results.erl
+++ b/src/rebar3_hex_results.erl
@@ -1,0 +1,66 @@
+-module(rebar3_hex_results).
+
+-export([errors_to_string/1, print_table/1]).
+
+-include("rebar3_hex.hrl").
+
+errors_to_string(Value) when is_binary(Value) ->
+    Value;
+errors_to_string(Map) when is_map(Map) ->
+    errors_to_string(maps:to_list(Map));
+errors_to_string({<<"inserted_at">>, E}) ->
+    lists:flatten(io_lib:format("Inserted At: ~s~n", [E]));
+errors_to_string({<<"requirements">>,  Rs}) ->
+    lists:flatten(["Requirements could not be computed\n",
+                  [io_lib:format("~s\n~20.20c\n~s\n",[P,$-, R]) || {P, R} <- maps:to_list(Rs)]]);
+errors_to_string({Key, Value}) ->
+    io_lib:format("~s: ~s", [Key, errors_to_string(Value)]);
+errors_to_string(Errors) when is_list(Errors) ->
+    lists:flatten([io_lib:format("~s", [errors_to_string(Values)]) || Values <- Errors]).
+
+print_table(Rows) ->
+    Table = table(Rows),
+    io:fwrite(Table),
+    ok.
+
+underline_emphasis(Item) ->
+    io_lib:format("\e[1m\e[00m\e[4m~ts\e[24m", [Item]).
+
+% Returns a str, expects first row to be a header
+table(Rows) ->
+    [Header | Body] = align_rows(Rows),
+    Table = [pretty_header(Header), ""] ++ Body,
+    lists:foldl(fun(Row, Acc) ->
+                        Acc ++ [io_lib:fwrite("~s~n", [lists:flatten(Row)])]
+                end,
+                [],
+                Table).
+
+pretty_header(Header) ->
+    lists:map(fun(W) ->
+                      [Value, Space] = rebar3_hex_utils:str_split(W, " "),
+                      underline_emphasis(Value) ++ " "  ++ Space  end,
+              Header).
+
+align_rows(Rows) ->
+    WidestCells = widest_cells(Rows),
+    [align_cells(R, WidestCells) || R <- Rows].
+
+align_cells(Row, WidestCells) ->
+    Padded = rpad_row(Row, length(WidestCells), ""),
+    [ string:left(Cell, Length + 2, $\s)
+      || {Cell, Length} <- lists:zip(Padded, WidestCells)].
+
+widest_cells(Rows) ->
+    lists:foldl( fun(Row, Acc) ->
+                         CellLengths = [length(C) || C <- Row ],
+                         Widest = lists:max([length(Acc), length(CellLengths)]),
+                         Padded = rpad_row(CellLengths, Widest, 0),
+                         WidestPadded = rpad_row(Acc, Widest, 0),
+                         [ lists:max([A, B]) || {A, B} <- lists:zip(Padded, WidestPadded)]
+                 end,
+                 [],
+                 Rows).
+
+rpad_row(L, Length, Elem) ->
+    L ++ lists:duplicate(Length - length(L), Elem).

--- a/src/rebar3_hex_search.erl
+++ b/src/rebar3_hex_search.erl
@@ -54,7 +54,7 @@ search(State, Repo, Term) ->
                                       latest_stable(Releases), Descrip, unicode:characters_to_list(Url)]
 
                              end, sort_by_downloads(Packages)),
-            ok = print_table([Header] ++ Rows),
+            ok = rebar3_hex_results:print_table([Header] ++ Rows),
             {ok, State};
         {ok, {Status, _Headers, _Body}} ->
             ?PRV_ERROR({status, Status});
@@ -124,50 +124,3 @@ format_error({error, Reason}) ->
     io_lib:format("Error searching for packages: ~p", [Reason]);
 format_error(Reason) ->
     io_lib:format("~p", [Reason]).
-
-print_table(Rows) ->
-    Table = table(Rows),
-    io:fwrite(Table),
-    ok.
-
-underline_emphasis(Item) ->
-    io_lib:format("\e[1m\e[00m\e[4m~ts\e[24m", [Item]).
-
-% Returns a str, expects first row to be a header
-table(Rows) ->
-    [Header | Body] = align_rows(Rows),
-    Table = [pretty_header(Header), ""] ++ Body,
-    lists:foldl(fun(Row, Acc) ->
-                        Acc ++ [io_lib:fwrite("~s~n", [lists:flatten(Row)])]
-                end,
-                [],
-                Table).
-
-pretty_header(Header) ->
-    lists:map(fun(W) ->
-                      [Value, Space] = rebar3_hex_utils:str_split(W, " "),
-                      underline_emphasis(Value) ++ " "  ++ Space  end,
-              Header).
-
-align_rows(Rows) ->
-    WidestCells = widest_cells(Rows),
-    [align_cells(R, WidestCells) || R <- Rows].
-
-align_cells(Row, WidestCells) ->
-    Padded = rpad_row(Row, length(WidestCells), ""),
-    [ string:left(Cell, Length + 2, $\s)
-      || {Cell, Length} <- lists:zip(Padded, WidestCells)].
-
-widest_cells(Rows) ->
-    lists:foldl( fun(Row, Acc) ->
-                         CellLengths = [length(C) || C <- Row ],
-                         Widest = lists:max([length(Acc), length(CellLengths)]),
-                         Padded = rpad_row(CellLengths, Widest, 0),
-                         WidestPadded = rpad_row(Acc, Widest, 0),
-                         [ lists:max([A, B]) || {A, B} <- lists:zip(Padded, WidestPadded)]
-                 end,
-                 [],
-                 Rows).
-
-rpad_row(L, Length, Elem) ->
-    L ++ lists:duplicate(Length - length(L), Elem).

--- a/src/rebar3_hex_utils.erl
+++ b/src/rebar3_hex_utils.erl
@@ -15,9 +15,14 @@
          get_password/1,
          update_auth_config/2,
          str_split/2,
-         get_required/2]).
+         get_required/2,
+         task_args/1]).
 
 -include("rebar3_hex.hrl").
+
+task_args(State) ->
+    {[{task, Task} | Args], _} = rebar_state:command_parsed_args(State),
+    {Task, Args}.
 
 pretty_print_status(401) -> "Authentication failed (401)";
 pretty_print_status(403) -> "Forbidden (403)";

--- a/test/support/hex_api_model.erl
+++ b/test/support/hex_api_model.erl
@@ -156,6 +156,62 @@ handle('GET', [<<"users">>, <<"me">>], Req) ->
                     end,
     respond_with(Status, Req, Res);
 
+handle('GET', [<<"keys">>], Req) ->
+    Key = elli_request:get_header(<<"Authorization">>, Req),
+    {Status, Res} = case Key of
+                        <<"eh?">> ->
+                            {422, #{<<"message">> => <<"huh?">>}};
+                        <<"bad">> ->
+                            {500, #{<<"whoa">> => <<"mr.">>}};
+                        _Other ->
+                            Res0 = [
+                                    #{<<"name">> => <<"key1">>,
+                                     <<"inserted_at">> => <<"2019-05-27T20:49:35Z">>
+                                    },
+                                    #{<<"name">> => <<"key2">>,
+                                     <<"inserted_at">> => <<"2019-06-27T20:49:35Z">>
+                                    }
+                                   ],
+                            {200, Res0}
+                    end,
+    respond_with(Status, Req, Res);
+
+handle('GET', [<<"keys">>, <<"key">>], Req) ->
+    Res = #{
+            <<"authing_key">> => false,
+            <<"inserted_at">> => <<"2019-03-23T17:47:35Z">>,
+            <<"last_use">>=> #{
+                                <<"ip">> => <<"173.166.199.194">>,
+                                <<"used_at">> => <<"2019-04-16T03:11:05Z">>,
+                                <<"user_agent">> => <<"hex_core/0.5.0 (rebar3/3.9.1+build.4339.refd29728e) (httpc) (OTP/21) (erts/10.2.5)">>
+                                },
+            <<"name">>=><<"mr_pockets_house">>,
+            <<"permissions">>=>[
+                                #{
+                                    <<"domain">>=><<"api">>,
+                                    <<"resource">>=>nil
+                                }
+                               ],
+            <<"revoked_at">>=>nil,
+            <<"secret">>=>nil,
+            <<"updated_at">>=><<"2019-04-16T03:11:05Z">>,
+            <<"url">>=><<"https://hex.pm/api/keys/mr_pockets_house">>
+     },
+    respond_with(200, Req, Res);
+
+handle('PUT', [<<"keys">>], Req) ->
+    Res = #{},
+    respond_with(201, Req, Res);
+
+
+handle('DELETE', [<<"keys">>], Req) ->
+    Res = #{},
+    respond_with(200, Req, Res);
+
+handle('DELETE', [<<"keys">>, <<"key">>], Req) ->
+    Res = #{<<"secret">> => <<"repo_key">>},
+    respond_with(200, Req, Res);
+
 handle(_, _, Req) ->
     respond_with(404, Req, #{}).
 


### PR DESCRIPTION
    Implement key commands

     - support for listing, fetching, generating and revoking of keys
     - create rebar3_hex_results and move table functions to here for reuse
       by key module
     - Added experimental rebar3_hex_client to keep hex_core isolated and
         http response handling abstracted