### PR TITLE
Always store an .app.src file in the package

### DIFF
--- a/src/rebar3_hex_publish.erl
+++ b/src/rebar3_hex_publish.erl
@@ -272,7 +272,7 @@ include_files(Name, AppDir, AppDetails) ->
 
     AppFileSrc = filename:join("src", ec_cnv:to_list(Name)++".app.src"),
     AppSrcBinary = ec_cnv:to_binary(lists:flatten(io_lib:format("~tp.\n", [AppSrc]))),
-    lists:keyreplace(AppFileSrc, 1, WithIncludes, {AppFileSrc, AppSrcBinary}).
+    lists:keystore(AppFileSrc, 1, WithIncludes, {AppFileSrc, AppSrcBinary}).
 
 
 is_valid_app({_App, _Name, _Version, _AppDetails} = A) ->


### PR DESCRIPTION
In pull request #116, the behavior changed a bit: the generated `.app.src` file was included in the package (the tar archive) only if one was already listed in the included files. Before this changed, the generated `.app.src` file was already prepended to that list.

Therefore, if the initial `.app.src` was missing from that list, no `.app.src` was added to the package.

This commit restores the previous behavior: the generated `.app.src` replaces the initial file or it is added (appended) to the list.

This solves an issue where Erlang.mk-based packages (which may not have an `.app.src` file on disk), published using this plugin to Hex.pm, were published successfully but were considered invalid when fetched as a dependency later:

```
===> Dependency failure: source for (...) does not contain a recognizable project and can not be built
```