### PR TITLE
Use the win32 method for getting passwords on all platforms

### DIFF
--- a/test/support/test_utils.erl
+++ b/test/support/test_utils.erl
@@ -38,7 +38,7 @@ mock_command(Command, Repo, State0) when is_tuple(Command) ->
 mock_command(Command, _Repo, State0) when is_list(Command) ->
     State1 = rebar_state:add_resource(State0, {pkg, rebar_pkg_resource}),
     State2 = rebar_state:create_resources([{pkg, rebar_pkg_resource}], State1),
-    State3 = rebar_state:command_args(State2, Command).
+    rebar_state:command_args(State2, Command).
 
 new_mock_command(ProviderName, Command, Repo, State0) ->
     State1 = rebar_state:add_resource(State0, {pkg, rebar_pkg_resource}),


### PR DESCRIPTION
In light of `io` problems that should be dealt with in Erlang/OTP in regards to echoless prompts we should switch to the same method of prompting for passwords that we use on win32 ala mix/hex.

Specifically, we are seeing issues where by `io:setops/1` now consistently returns `{error, notsup}` where it should return `ok` per the platform (e.g., mac os, linux, *bsd, etc.). Until we can safely depend on `io:getline/1` and/or `io:get_password/1` we should resort to what appears to be the only reliable method for getting a password. That is reading and clearing the input at a prompt every 1ms. 