### PR TITLE
publish package response doesn't have content-type response header

### DIFF
--- a/src/rebar3_hex_docs.erl
+++ b/src/rebar3_hex_docs.erl
@@ -91,7 +91,7 @@ do_publish(App, State, Repo) ->
     {ok, Config} = rebar3_hex_config:hex_config_write(Repo),
 
     case rebar3_hex_client:publish_docs(Config, rebar_utils:to_binary(PkgName), rebar_utils:to_binary(Vsn), Tar) of
-        {created, <<>>} ->
+        {created, _} ->
             rebar_api:info("Published docs for ~ts ~ts", [PkgName, Vsn]),
             {ok, State};
         Reason ->


### PR DESCRIPTION
after runing  `$ rebar3 hex docs` I got the `===> {publish,{created,nil}}` result
the request was success, but was not `{created, <<>>}` the result
