### PR TITLE
Handle key list with repo argument

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -14,10 +14,10 @@
 {profiles, [
     {test, [
         {overrides, [{override, rebar3,[{deps, [{erlware_commons, "1.2.0"}]}]}]},
-        {deps, [{hex_core, "0.6.3"},
+        {deps, [{hex_core, "0.6.8"},
                 {rebar, {git, "git://github.com/erlang/rebar3.git", {tag, "v3.13.1"}}},
-                {erlware_commons, "1.2.0"}, {elli, "3.0.0"},
-                {jsone, "1.4.7"}, {meck, "0.8.12"}]},
+                {erlware_commons, "1.2.0"}, {elli, "3.2.0"},
+                {jsone, "1.5.2"}, {meck, "0.8.13"}]},
         {erl_opts, [nowarn_export_all]}
     ]}
 ]}.

--- a/src/rebar3_hex.erl
+++ b/src/rebar3_hex.erl
@@ -1,6 +1,6 @@
 -module(rebar3_hex).
 
--export([init/1, get_required/2, task_args/1, repo_opt/0, help_opt/0, sub_command/1]).
+-export([init/1, get_required/2, task_args/1, repo_opt/0, help_opt/0]).
 
 init(State) ->
     lists:foldl(fun provider_init/2, {ok, State}, [rebar3_hex_user,

--- a/src/rebar3_hex.erl
+++ b/src/rebar3_hex.erl
@@ -1,6 +1,6 @@
 -module(rebar3_hex).
 
--export([init/1, get_required/2, task_args/1, repo_opt/0, help_opt/0]).
+-export([init/1, get_required/2, task_args/1, repo_opt/0, help_opt/0, sub_command/1]).
 
 init(State) ->
     lists:foldl(fun provider_init/2, {ok, State}, [rebar3_hex_user,
@@ -28,6 +28,12 @@ get_required(Key, Args) ->
 task_args(State) ->
     {[{task, Task} | Args], _} = rebar_state:command_parsed_args(State),
     {Task, Args}.
+
+sub_command(State) ->
+  case rebar_state:command_args(State) of
+      [] -> undefined;
+      [Cmd|_] -> Cmd
+  end.
 
 repo_opt() ->
   {repo, $r, "repo", string, "Repository to use for this command."}.

--- a/src/rebar3_hex.erl
+++ b/src/rebar3_hex.erl
@@ -29,12 +29,6 @@ task_args(State) ->
     {[{task, Task} | Args], _} = rebar_state:command_parsed_args(State),
     {Task, Args}.
 
-sub_command(State) ->
-  case rebar_state:command_args(State) of
-      [] -> undefined;
-      [Cmd|_] -> Cmd
-  end.
-
 repo_opt() ->
   {repo, $r, "repo", string, "Repository to use for this command."}.
 

--- a/src/rebar3_hex_config.erl
+++ b/src/rebar3_hex_config.erl
@@ -5,6 +5,7 @@
          , repos_key_name/0
          , org_key_name/2
          , parent_repos/1
+         , hex_config/2
          , hex_config_write/1
          , hex_config_read/1
          , repo/1
@@ -149,6 +150,12 @@ get_repo(BinaryName, Repos) ->
             Name
     catch
         {error,{rebar_hex_repos,{repo_not_found,BinaryName}}} -> undefined
+    end.
+
+hex_config(Repo, Op) ->
+    case Op of
+        read ->  hex_config_read(Repo);
+        write -> hex_config_write(Repo)
     end.
 
 hex_config_write(#{api_key := Key} = HexConfig) when is_binary(Key) ->

--- a/src/rebar3_hex_error.erl
+++ b/src/rebar3_hex_error.erl
@@ -4,12 +4,22 @@
 
 format_error({required, repo}) ->
     "A repository argument is required for this command.";
+
 format_error({error, no_read_key}) ->
     "No read key found for user. Be sure to authenticate first with:"
     ++ " rebar3 hex user auth";
+
 format_error({error, no_write_key}) ->
     "No write key found for user. Be sure to authenticate first with:"
     ++ " rebar3 hex user auth";
+
+format_error({Cmd, unsupported_params}) ->
+    io_lib:format("Either some or all of the parameters supplied for the ~ts command are ", [Cmd])
+    ++ "invalid or form an invalid combination of parameters.";
+
+format_error({Cmd, missing_required_params}) ->
+    io_lib:format("Required parameters for the ~ts command have not been supplied.", [Cmd]);
+
 format_error(Reason) ->
     try io_lib:format("~p", [Reason]) of
         Result ->

--- a/src/rebar3_hex_error.erl
+++ b/src/rebar3_hex_error.erl
@@ -7,15 +7,15 @@ format_error({required, repo}) ->
 
 format_error({error, no_read_key}) ->
     "No read key found for user. Be sure to authenticate first with:"
-    ++ " rebar3 hex user auth";
+    " rebar3 hex user auth";
 
 format_error({error, no_write_key}) ->
     "No write key found for user. Be sure to authenticate first with:"
-    ++ " rebar3 hex user auth";
+    " rebar3 hex user auth";
 
 format_error({Cmd, unsupported_params}) ->
     io_lib:format("Either some or all of the parameters supplied for the ~ts command are ", [Cmd])
-    ++ "invalid or form an invalid combination of parameters.";
+    " invalid or form an invalid combination of parameters.";
 
 format_error({Cmd, missing_required_params}) ->
     io_lib:format("Required parameters for the ~ts command have not been supplied.", [Cmd]);

--- a/src/rebar3_hex_error.erl
+++ b/src/rebar3_hex_error.erl
@@ -4,6 +4,12 @@
 
 format_error({required, repo}) ->
     "A repository argument is required for this command.";
+format_error({error, no_read_key}) ->
+    "No read key found for user. Be sure to authenticate first with:"
+    ++ " rebar3 hex user auth";
+format_error({error, no_write_key}) ->
+    "No write key found for user. Be sure to authenticate first with:"
+    ++ " rebar3 hex user auth";
 format_error(Reason) ->
     try io_lib:format("~p", [Reason]) of
         Result ->

--- a/src/rebar3_hex_error.erl
+++ b/src/rebar3_hex_error.erl
@@ -15,7 +15,7 @@ format_error({error, no_write_key}) ->
 
 format_error({Cmd, unsupported_params}) ->
     io_lib:format("Either some or all of the parameters supplied for the ~ts command are ", [Cmd])
-    " invalid or form an invalid combination of parameters.";
+    ++ " invalid or form an invalid combination of parameters.";
 
 format_error({Cmd, missing_required_params}) ->
     io_lib:format("Required parameters for the ~ts command have not been supplied.", [Cmd]);

--- a/src/rebar3_hex_key.erl
+++ b/src/rebar3_hex_key.erl
@@ -70,15 +70,8 @@ handle_command({"revoke", _Params}, _State, _Repo) ->
 handle_command(_, _, _) ->
     ?PRV_ERROR(bad_command).
 
-perform(State, Repo, read, Fun, Params) ->
-    case rebar3_hex_config:hex_config_read(Repo) of
-      {ok, Config} ->
-          Fun(State, Config, Params);
-      Err ->
-          ?PRV_ERROR(Err)
-    end;
-perform(State, Repo, write, Fun, Params) ->
-    case rebar3_hex_config:hex_config_write(Repo) of
+perform(State, Repo, RepoContext, Fun, Params) ->
+    case rebar3_hex_config:hex_config(Repo, RepoContext) of
       {ok, Config} ->
           Fun(State, Config, Params);
       Err ->

--- a/src/rebar3_hex_key.erl
+++ b/src/rebar3_hex_key.erl
@@ -53,7 +53,6 @@ handle_command("fetch", State, Repo) ->
     {ok, Config} = rebar3_hex_config:hex_config_read(Repo),
     fetch(State, Config, KeyName);
 
-
 handle_command("list", State, Repo) ->
     {ok, Config} = rebar3_hex_config:hex_config_read(Repo),
     list(State, Config);

--- a/src/rebar3_hex_key.erl
+++ b/src/rebar3_hex_key.erl
@@ -1,8 +1,6 @@
 -module(rebar3_hex_key).
 
--export([init/1,
-         do/1,
-         format_error/1]).
+-export([init/1, do/1, format_error/1]).
 
 -include("rebar3_hex.hrl").
 
@@ -16,148 +14,143 @@ init(State) ->
                                  {namespace, hex},
                                  {bare, true},
                                  {deps, ?DEPS},
-                                 {example, "rebar3 hex key [generate -k <key> | list | revoke -k <key> | revoke --all]"},
-                                 {short_desc, "Remove or list API keys associated with your account"},
+                                 {example,
+                                  "rebar3 hex key [generate -k <key> | list | revoke -k <key> "
+                                  "| revoke --all]"},
+                                 {short_desc,
+                                  "Remove or list API keys associated with your account"},
                                  {desc, ""},
-                                 {opts, [
-                                         {all, $a, "all", boolean, "all."},
-                                         {keyname, $k, "key-name", string, "key-name"},
-                                         {permission, $p, "permission", list, "perms."},
-                                         rebar3_hex:repo_opt()
-                                        ]
-                                 }]),
+                                 {opts,
+                                  [{all, $a, "all", boolean, "all."},
+                                   {keyname, $k, "key-name", string, "key-name"},
+                                   {permission, $p, "permission", list, "perms."},
+                                   rebar3_hex:repo_opt()]}]),
     State1 = rebar_state:add_provider(State, Provider),
     {ok, State1}.
 
 -spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, term()}.
 do(State) ->
     case rebar3_hex_config:repo(State) of
-        {ok, Repo} ->
-            TaskArgs = rebar3_hex:task_args(State),
-            handle_command(TaskArgs, State, Repo);
-        {error, Reason} ->
-            ?PRV_ERROR(Reason)
+      {ok, Repo} ->
+          TaskArgs = rebar3_hex:task_args(State),
+          handle_command(TaskArgs, State, Repo);
+      {error, Reason} ->
+          ?PRV_ERROR(Reason)
     end.
 
 handle_command({"generate", Params}, State, Repo) ->
     case rebar3_hex_config:hex_config_write(Repo) of
-        {ok, Config} ->
-            generate(State, Config, Params);
-        Err ->
-            ?PRV_ERROR(Err)
+      {ok, Config} ->
+          generate(State, Config, Params);
+      Err ->
+          ?PRV_ERROR(Err)
     end;
-
-handle_command({"fetch", Params}, State, Repo) ->
+handle_command({"fetch", []}, _State, _Repo) ->
+    ?PRV_ERROR({fetch, missing_required_params});
+handle_command({"fetch", [{keyname, KeyName}]}, State, Repo) ->
     case rebar3_hex_config:hex_config_read(Repo) of
-        {ok, Config} ->
-            case Params of
-                [{keyname, KeyName}] ->
-                    fetch(State, Config, KeyName);
-                [] ->
-                    ?PRV_ERROR({fetch, missing_required_params})
-            end;
-        Err ->
-            ?PRV_ERROR(Err)
+      {ok, Config} ->
+          fetch(State, Config, KeyName);
+      Err ->
+          ?PRV_ERROR(Err)
     end;
-
-handle_command({"list", _Params},  State, Repo) ->
+handle_command({"list", _Params}, State, Repo) ->
     case rebar3_hex_config:hex_config_read(Repo) of
-        {ok, Config} ->
-            list(State, Config);
-        Err ->
-            ?PRV_ERROR(Err)
+      {ok, Config} ->
+          list(State, Config);
+      Err ->
+          ?PRV_ERROR(Err)
     end;
-
-handle_command({"revoke", Params}, State, Repo) ->
+handle_command({"revoke", [{keyname, KeyName}]}, State, Repo) ->
     case rebar3_hex_config:hex_config_write(Repo) of
-        {ok, Config} ->
-            case Params of
-               [{all,true}]  ->
-                    revoke_all(State, Config);
-               [{keyname, KeyName}] ->
-                    revoke(State, Config, KeyName);
-               _ ->
-                 ?PRV_ERROR({revoke, unsupported_params})
-            end;
-        Err ->
-            ?PRV_ERROR(Err)
+      {ok, Config} ->
+          revoke(State, Config, KeyName);
+      Err ->
+          ?PRV_ERROR(Err)
     end;
-
+handle_command({"revoke", [{all, true}]}, State, Repo) ->
+    case rebar3_hex_config:hex_config_write(Repo) of
+      {ok, Config} ->
+          revoke_all(State, Config);
+      Err ->
+          ?PRV_ERROR(Err)
+    end;
+handle_command({"revoke", _Params}, _State, _Repo) ->
+    ?PRV_ERROR({revoke, unsupported_params});
 handle_command(_, _, _) ->
     ?PRV_ERROR(bad_command).
 
 generate(State, HexConfig, Params) ->
     Perms = gather_permissions(proplists:get_all_values(permission, Params)),
-    KeyName =  proplists:get_value(keyname, Params, undefined),
+    KeyName = proplists:get_value(keyname, Params, undefined),
     case rebar3_hex_client:key_add(HexConfig, KeyName, Perms) of
-        {ok, _Res} ->
-            rebar3_hex_io:say("Key successfully created", []),
-            {ok, State};
-        Error ->
-            ?PRV_ERROR({generate, Error})
+      {ok, _Res} ->
+          rebar3_hex_io:say("Key successfully created", []),
+          {ok, State};
+      Error ->
+          ?PRV_ERROR({generate, Error})
     end.
 
 fetch(State, HexConfig, KeyName) ->
     case rebar3_hex_client:key_get(HexConfig, KeyName) of
-        {ok, Res} ->
-            ok = print_key_details(Res),
-            {ok, State};
-        Error ->
-            ?PRV_ERROR({fetch, Error})
+      {ok, Res} ->
+          ok = print_key_details(Res),
+          {ok, State};
+      Error ->
+          ?PRV_ERROR({fetch, Error})
     end.
 
 revoke(State, HexConfig, KeyName) ->
     case rebar3_hex_client:key_delete(HexConfig, KeyName) of
-        {ok, _Res} ->
-             rebar3_hex_io:say("Key successfully revoked", []),
-            {ok, State};
-        Error ->
-            ?PRV_ERROR({revoke, Error})
+      {ok, _Res} ->
+          rebar3_hex_io:say("Key successfully revoked", []),
+          {ok, State};
+      Error ->
+          ?PRV_ERROR({revoke, Error})
     end.
 
 revoke_all(State, HexConfig) ->
     case rebar3_hex_client:key_delete_all(HexConfig) of
-        {ok, _Res} ->
-            rebar3_hex_io:say("All keys successfully revoked", []),
-            {ok, State};
-        Error ->
-            ?PRV_ERROR({revoke_all, Error})
+      {ok, _Res} ->
+          rebar3_hex_io:say("All keys successfully revoked", []),
+          {ok, State};
+      Error ->
+          ?PRV_ERROR({revoke_all, Error})
     end.
 
 list(State, HexConfig) ->
     case rebar3_hex_client:key_list(HexConfig) of
-        {ok, Res} ->
-            ok = print_results(Res),
-            {ok, State};
-        Error ->
-            ?PRV_ERROR({list, Error})
+      {ok, Res} ->
+          ok = print_results(Res),
+          {ok, State};
+      Error ->
+          ?PRV_ERROR({list, Error})
     end.
 
 gather_permissions([]) ->
     [];
 gather_permissions(Perms) ->
-    lists:foldl(fun(Name, Acc) ->
-                [Domain, Resource] = binary:split(rebar_utils:to_binary(Name), <<":">>),
-                [#{<<"domain">> => Domain, <<"resource">> => Resource}] ++ Acc
-                end, [], Perms).
+    lists:foldl(fun (Name, Acc) ->
+                        [Domain, Resource] = binary:split(rebar_utils:to_binary(Name), <<":">>),
+                        [#{<<"domain">> => Domain, <<"resource">> => Resource}] ++ Acc
+                end,
+                [],
+                Perms).
 
 print_results(Res) ->
     Header = ["Name", "Created"],
-    Rows = lists:map(fun(#{<<"name">> := Name, <<"inserted_at">> := Created}) ->
-                                [binary_to_list(Name), binary_to_list(Created)]
-                     end, Res),
+    Rows = lists:map(fun (#{<<"name">> := Name, <<"inserted_at">> := Created}) ->
+                             [binary_to_list(Name), binary_to_list(Created)]
+                     end,
+                     Res),
     ok = rebar3_hex_results:print_table([Header] ++ Rows),
     ok.
+
 print_key_details(#{<<"name">> := Name,
                     <<"inserted_at">> := Created,
                     <<"updated_at">> := Updated,
-                    <<"last_use">> := #{
-                        <<"ip">> := Addr,
-                        <<"used_at">> := Used,
-                        <<"user_agent">> := _Agent
-                       }
-                   }
-                 ) ->
+                    <<"last_use">> :=
+                        #{<<"ip">> := Addr, <<"used_at">> := Used, <<"user_agent">> := _Agent}}) ->
     Header = ["Name", "Created", "Updated", "LastUsed", "LastUsedBy"],
     Row = [binary_to_list(Name),
            binary_to_list(Created),
@@ -170,14 +163,17 @@ print_key_details(#{<<"name">> := Name,
 -spec format_error(any()) -> iolist().
 format_error({list, {unauthorized, _Res}}) ->
     "Error while attempting to perform list : Not authorized";
-format_error({list,{error,#{<<"message">> := Msg}}}) ->
-   "Error while attempting to perform list : " ++ Msg;
+format_error({list, {error, #{<<"message">> := Msg}}}) ->
+    "Error while attempting to perform list : " ++ Msg;
 format_error({revoke, {not_found, _Res}}) ->
     "Error while revoking key : key not found";
-format_error({generate, {validation_errors, #{<<"errors">> := Errors, <<"message">> := Message}}}) ->
+format_error({generate,
+              {validation_errors, #{<<"errors">> := Errors, <<"message">> := Message}}}) ->
     ErrorString = rebar3_hex_results:errors_to_string(Errors),
     io_lib:format("~ts~n\t~ts", [Message, ErrorString]);
 format_error(bad_command) ->
-    "Unknown command. Command must be fetch, generate, list, or revoke";
+    "Unknown command. Command must be fetch, generate, list, or "
+    "revoke";
 format_error(Reason) ->
     rebar3_hex_error:format_error(Reason).
+

--- a/test/rebar3_hex_integration_SUITE.erl
+++ b/test/rebar3_hex_integration_SUITE.erl
@@ -479,21 +479,21 @@ key_list_test(Config) ->
 key_get_test(Config) ->
     P = #{app => "valid", mocks => []},
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
-    {ok, GetState} = test_utils:mock_command(rebar3_hex_key, ["fetch", "key"], Repo, State),
+    {ok, GetState} = test_utils:mock_command(rebar3_hex_key, ["fetch", "-k", "key"], Repo, State),
 
     ?assertMatch({ok, GetState}, rebar3_hex_key:do(GetState)).
 
 key_add_test(Config) ->
     P = #{app => "valid", mocks => [key_mutation]},
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
-    {ok, AddState} = test_utils:mock_command(rebar3_hex_key, ["generate", "foo"], Repo, State),
+    {ok, AddState} = test_utils:mock_command(rebar3_hex_key, ["generate", "-k", "foo"], Repo, State),
 
     ?assertMatch({ok, AddState}, rebar3_hex_key:do(AddState)).
 
 key_delete_test(Config) ->
     P = #{app => "valid", mocks => [key_mutation]},
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
-    {ok, AddState} = test_utils:mock_command(rebar3_hex_key, ["revoke", "key"], Repo, State),
+    {ok, AddState} = test_utils:mock_command(rebar3_hex_key, ["revoke", "-k", "key"], Repo, State),
 
     ?assertMatch({ok, AddState}, rebar3_hex_key:do(AddState)).
 


### PR DESCRIPTION
Due to how we were matching on command arguments a key list command with a repo argument would result a in crash.

 - add rebar3_hex:sub_command/1
 - refactor handle_command/2 to handle_command/3 in rebar3_hex_key
 - update test deps in rebar.config