### PR TITLE
Add catch all for publishing when a message is available

### DIFF
--- a/src/rebar3_hex_publish.erl
+++ b/src/rebar3_hex_publish.erl
@@ -230,19 +230,17 @@ maybe_say_coc(_) ->
 create_and_publish(Metadata, PackageFiles, HexConfig) ->
     {ok, #{tarball := Tarball, inner_checksum := _Checksum}} = hex_tarball:create(Metadata, PackageFiles),
     case hex_api_release:publish(HexConfig, Tarball) of
-        {ok, {400, _Headers, #{<<"message">> := Message}}} ->
-            ?PRV_ERROR({publish_failed, Message});
-        {ok, {401, _Headers, #{<<"message">> := Message}}} ->
-            ?PRV_ERROR({publish_failed, Message});
-        {ok, {422, _Headers, #{<<"errors">> := Errors,
-                               <<"message">> := Message}}} ->
-            ?PRV_ERROR({validation_errors, Errors, Message});
         {ok, {201, _Headers, _Body}} ->
             ok;
         {ok, {200, _Headers, _Body}} ->
             ok;
+        {ok, {422, _Headers, #{<<"errors">> := Errors,
+                               <<"message">> := Message}}} ->
+            ?PRV_ERROR({validation_errors, Errors, Message});
         {ok, {500, _Headers, _Body}} ->
             ?PRV_ERROR({error, "Internal Server Error"});
+        {ok, {_Status, _Headers, #{<<"message">> := Message}}} ->
+            ?PRV_ERROR({publish_failed, Message});
         {error, Reason} ->
             ?PRV_ERROR({error, Reason})
     end.

--- a/test/support/hex_api_model.erl
+++ b/test/support/hex_api_model.erl
@@ -92,6 +92,8 @@ handle('POST', [<<"publish">>], Req) ->
                 }
             },
            respond_with(201, Req, Res);
+       unauthorized ->
+            respond_with(403, Req, #{<<"message">> => <<"account not authorized for this action">>});
        error ->
            respond_with(401, Req, #{})
    end;
@@ -125,7 +127,9 @@ handle('POST', [<<"repos">>, _Repo, <<"publish">>], Req) ->
                 }
             },
            respond_with(201, Req, Res);
-       error ->
+       unauthorized ->
+            respond_with(403, Req, #{<<"message">> => <<"account not authorized for this action">>});
+        error ->
            respond_with(401, Req, #{})
    end;
 
@@ -308,6 +312,8 @@ authenticate(Req) ->
                    organization => <<"hexpm">>,
                    source => key,
                    key => <<"key">>}};
+        <<"unauthorized">> ->
+            unauthorized;
         _ ->
             error
     end.


### PR DESCRIPTION
- Instead of matching on every possible http status code,
  have a catch all for when there it is an unexpected status but has a
  message from the server.
- closes #150