### PR TITLE
Update rebar3_hex_key to handle conditional last_use k/v

### DIFF
--- a/src/rebar3_hex_key.erl
+++ b/src/rebar3_hex_key.erl
@@ -145,17 +145,6 @@ print_results(Res) ->
     ok.
 
 
-print_key_details(#{<<"name">> := Name,
-                    <<"inserted_at">> := Created,
-                    <<"updated_at">> := Updated}) ->
-    Header = ["Name", "Created", "Updated", "LastUsed", "LastUsedBy"],
-    Row = [binary_to_list(Name),
-           binary_to_list(Created),
-           binary_to_list(Updated),
-           "never",
-           "n/a"],
-    ok = rebar3_hex_results:print_table([Header] ++ [Row]),
-    ok;
 
 print_key_details(#{<<"name">> := Name,
                     <<"inserted_at">> := Created,
@@ -168,6 +157,18 @@ print_key_details(#{<<"name">> := Name,
            binary_to_list(Updated),
            binary_to_list(Used),
            binary_to_list(Addr)],
+    ok = rebar3_hex_results:print_table([Header] ++ [Row]),
+    ok;
+
+print_key_details(#{<<"name">> := Name,
+                    <<"inserted_at">> := Created,
+                    <<"updated_at">> := Updated}) ->
+    Header = ["Name", "Created", "Updated", "LastUsed", "LastUsedBy"],
+    Row = [binary_to_list(Name),
+           binary_to_list(Created),
+           binary_to_list(Updated),
+           "never",
+           "n/a"],
     ok = rebar3_hex_results:print_table([Header] ++ [Row]),
     ok.
 

--- a/src/rebar3_hex_key.erl
+++ b/src/rebar3_hex_key.erl
@@ -144,6 +144,19 @@ print_results(Res) ->
     ok = rebar3_hex_results:print_table([Header] ++ Rows),
     ok.
 
+
+print_key_details(#{<<"name">> := Name,
+                    <<"inserted_at">> := Created,
+                    <<"updated_at">> := Updated}) ->
+    Header = ["Name", "Created", "Updated", "LastUsed", "LastUsedBy"],
+    Row = [binary_to_list(Name),
+           binary_to_list(Created),
+           binary_to_list(Updated),
+           "never",
+           "n/a"],
+    ok = rebar3_hex_results:print_table([Header] ++ [Row]),
+    ok;
+
 print_key_details(#{<<"name">> := Name,
                     <<"inserted_at">> := Created,
                     <<"updated_at">> := Updated,


### PR DESCRIPTION
 The `last_use` map key/val is conditionally returned by hex.pm and in the case it is
 not returned a function clause error will be raised.

 - add a clause that takes into account that last_use might not be
 returned and will subtitute it's printed column values with `never` and
 `n/a` in that case.