### PR TITLE
Add support for replace package option

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,12 +9,12 @@
 
 {project_plugins, [covertool]}.
 
-{deps, [{hex_core, "0.6.8"}, {verl, "1.0.2"}]}.
+{deps, [{hex_core, "0.6.9"}, {verl, "1.0.2"}]}.
 
 {profiles, [
     {test, [
         {overrides, [{override, rebar3,[{deps, [{erlware_commons, "1.2.0"}]}]}]},
-        {deps, [{hex_core, "0.6.8"},
+        {deps, [{hex_core, "0.6.9"},
                 {rebar, {git, "git://github.com/erlang/rebar3.git", {tag, "v3.13.1"}}},
                 {erlware_commons, "1.2.0"}, {elli, "3.2.0"},
                 {jsone, "1.5.2"}, {meck, "0.8.13"}]},

--- a/src/rebar3_hex.erl
+++ b/src/rebar3_hex.erl
@@ -1,6 +1,6 @@
 -module(rebar3_hex).
 
--export([init/1, get_required/2, task_args/1, repo_opt/0, help_opt/0]).
+-export([init/1, gather_opts/2, get_required/2, task_args/1, repo_opt/0, help_opt/0]).
 
 init(State) ->
     lists:foldl(fun provider_init/2, {ok, State}, [rebar3_hex_user,
@@ -16,6 +16,17 @@ init(State) ->
 
 provider_init(Module, {ok, State}) ->
     Module:init(State).
+
+gather_opts(Targets, State) -> 
+    {Args, _} = rebar_state:command_parsed_args(State),
+    lists:foldl(fun(T, Acc) -> 
+                        case proplists:get_value(T, Args, undefined) of
+                            undefined -> 
+                                Acc;
+                            V -> 
+                                maps:put(T, V, Acc)
+                        end
+                end, #{}, Targets).
 
 get_required(Key, Args) ->
     case proplists:get_value(Key, Args) of

--- a/src/rebar3_hex_client.erl
+++ b/src/rebar3_hex_client.erl
@@ -6,6 +6,7 @@
          , key_delete/2
          , key_delete_all/1
          , key_list/1
+         , publish/3
          , publish_docs/4
          , delete_docs/3
          , test_key/2
@@ -52,6 +53,10 @@ test_key(HexConfig, Perms) ->
    Res = hex_api_auth:test(HexConfig, Perms),
    response(Res).
 
+publish(HexConfig, Tarball, Opts) ->
+    Res = hex_api_release:publish(HexConfig, Tarball, Opts),
+    response(Res).
+
 publish_docs(Repo, Name, Version, Tarball) ->
     {ok, Config} = rebar3_hex_config:hex_config_write(Repo),
 
@@ -76,6 +81,8 @@ response({ok, {204, _Headers, Res}}) ->
 response({ok, {N, _Headers, Res}}) when ?is_success(N) ->
     {ok, Res};
 response({ok, {401, _Headers, Res}}) ->
+    {error, Res};
+response({ok, {403, _Headers, Res}}) ->
     {error, Res};
 response({ok, {404, _Headers, Res}}) ->
     {error, Res};

--- a/test/rebar3_hex_SUITE.erl
+++ b/test/rebar3_hex_SUITE.erl
@@ -5,7 +5,20 @@
 -include_lib("eunit/include/eunit.hrl").
 
 all() ->
-    [init_test, repo_opt].
+    [task_args_test, gather_opts_test, init_test, help_test, repo_opt].
+
+
+gather_opts_test(_Config) -> 
+    State = rebar_state:new(),
+    CmdArgs = {[{foo,"bar"}, {count, 42}, {other, eh}], []},
+    State1 = rebar_state:command_parsed_args(State, CmdArgs),
+    ?assertMatch(#{count := 42, foo := "bar"}, rebar3_hex:gather_opts([count, foo], State1)).
+
+task_args_test(_Config) -> 
+    State = rebar_state:new(),
+    CmdArgs = {[{task, thing} | {[{foo,"bar"}, {count, 42}], []}], []},
+    State1 = rebar_state:command_parsed_args(State, CmdArgs),
+    ?assertMatch({thing,{[{foo,"bar"},{count,42}],[]}}, rebar3_hex:task_args(State1)).
 
 repo_opt(_Config) ->
     ?assertEqual({repo,114,"repo",string,
@@ -14,3 +27,31 @@ repo_opt(_Config) ->
 init_test(_Config) ->
     {ok, State} = rebar3_hex:init(rebar_state:new()),
     ?assertEqual(state_t, element(1, State)).
+
+%% Smoke test to ensure we don't crash
+help_test(_Config) -> 
+    %% Silent output during our tests
+    ok =  meck:new(io_lib, [unstick, passthrough]),
+    meck:expect(io_lib, format, 2, fun(_,_) -> "" end),
+    Checks = [
+                {rebar3_hex_publish, publish}, 
+                {rebar3_hex_revert, revert},
+                {rebar3_hex_cut, cut},
+                {rebar3_hex_key, key},
+                {rebar3_hex_owner, owner},
+                {rebar3_hex_repo, repo},
+                {rebar3_hex_retire, retire},
+                {rebar3_hex_search, search},
+                {rebar3_hex_user, user}
+               ],
+    lists:foreach(fun get_help/1, Checks),
+    meck:unload(io_lib),
+    ok.
+
+get_help({Mod, Task}) -> 
+    State = rebar_state:new(),
+    {ok, State1} = Mod:init(State),
+    Providers = rebar_state:providers(State1),
+    Provider = providers:get_provider(Task, Providers, hex),
+    ?assertMatch(ok, providers:help(Provider)).
+

--- a/test/rebar3_hex_publish_SUITE.erl
+++ b/test/rebar3_hex_publish_SUITE.erl
@@ -105,10 +105,12 @@ format_error_test(_Config) ->
                <<"myapp.app.src : deprecated field contributors found">>},
               {no_write_key,
                <<"No write key found for user. Be sure to authenticate first with: rebar3 hex user auth">>},
-              {{validation_errors, [<<"Bad things">>, {<<"More bad">>, <<"things">>}], <<"eh?">>},
+              {
+               {publish, {error, #{<<"message">> => <<"eh?">>, <<"errors">> => [<<"Bad things">>, {<<"More bad">>,
+                                                                                         <<"things">>}]}}},
                <<"Failed to publish package: eh?\n\tBad thingsMore bad: things">>
               },
-              {{publish_failed, "non sequitur"}, <<"Failed to publish package: non sequitur">>},
+              {{publish, {error, #{<<"message">> => "non sequitur"}}}, <<"Failed to publish package: non sequitur">>},
               {{non_hex_deps, ["dep1", "dep2", "dep3"]},
                <<"Can not publish package because the following deps are not available in hex: dep1, dep2, dep3">>},
               {undefined_server_error, <<"Unknown server error">>},

--- a/test/support/hex_api_model.erl
+++ b/test/support/hex_api_model.erl
@@ -54,6 +54,13 @@ handle('PUT', [<<"packages">>, _Name, <<"owners">>, _UserOrOrg], Req) ->
            respond_with(401, Req, #{})
    end;
 
+handle('DELETE', [<<"packages">>, _Name, <<"releases">>, _Version], Req) ->
+    case authenticate(Req) of
+       {ok, #{username := _Username, email := _Email}} ->
+           {204, [{<<"Foo">>, <<"Bar">>}], terms_to_body(Req, <<"">>)};
+       error ->
+           respond_with(401, Req, #{})
+   end;
 
 handle('DELETE', [<<"packages">>, _Name, <<"releases">>, _Version, <<"docs">>], Req) ->
     case authenticate(Req) of


### PR DESCRIPTION
hex_core and hex.pm have introduced an option to replace an existing
package, this commit surfaces

- upgrade to hex 0.6.9

- add --replace switch on publish command

- Fix up publish options, previously there were strings where atoms were
  expected (element 0 of the option tuple)

- make --revert fully supported and useable

- add --package to support the --revert switch

- Start follow the command pattern laid out by the key command

- Improve description with supportive documentation

- move call to hex_api_release into rebar3_hex_client as publish/2

- update test suites were required

# Output of rebar3 help for publish command

```
Publishes a new version of a package with options to revert and replace existing packages

Supported commmand combinations:

  rebar3 hex publish

  rebar3 hex publish --yes

  rebar3 hex publish --repo <repo>

  rebar3 hex publish --repo <repo> --yes

  rebar3 hex publish --revert <version> --package <package>

  rebar3 hex publish --revert <version> --package <package> --yes

  rebar3 hex publish --replace

  rebar3 hex publish --replace --yes

Argument descriptions:

  <repo>    - a valid repository, only required when multiple repositories are configured

  <version> - a valid version string, currently only utilized with --revert switch

  <package> - a valid package name, currently only utilized with --revert switch


Usage: rebar3 hex publish [-r <repo>] [-y [<yes>]] [--replace [<replace>]]
                          [-p <package>] [--revert <revert>]

  -r, --repo     Repository to use for this command.
  -y, --yes      Publishes the package without any confirmation prompts
                 [default: false]
  --replace      Allows overwriting an existing package version if it
                 exists. Private packages can always be overwritten,
                 publicpackages can only be overwritten within one hour
                 after they were initially published. [default: false]
  -p, --package  Specifies the package to use with the publish command,
                 currently only utilized in a revert operation
  --revert       Revert given version, if the last version is reverted the
                 package is removed
```

# TODO: 

- [x] Add tests for help on commands to ensure we do not crash
- [x] Add tests for --replace
- [x] Add tests for --revert