### PR TITLE
Do not dump data in case of unknown errors

### DIFF
--- a/src/rebar3_hex_error.erl
+++ b/src/rebar3_hex_error.erl
@@ -21,11 +21,5 @@ format_error({Cmd, missing_required_params}) ->
     io_lib:format("Required parameters for the ~ts command have not been supplied.", [Cmd]);
 
 format_error(Reason) ->
-    try io_lib:format("~p", [Reason]) of
-        Result ->
-            Result
-    catch
-        _:_  ->
-            io_lib:format("Unknown error encountered : ~ts", [Reason])
-    end.
-
+    rebar_api:debug("Unknown error : ~ts", [Reason]),
+    "An unknown error was encountered. Run with DEBUG=1 for more details.".

--- a/test/rebar3_hex_docs_SUITE.erl
+++ b/test/rebar3_hex_docs_SUITE.erl
@@ -21,5 +21,5 @@ format_error_test(_Config) ->
     Exp5 = "Error reverting docs : Package or Package Version not found",
     ?assertEqual(Exp5, rebar3_hex_docs:format_error({revert, {not_found, <<>>}})),
 
-    Exp6 = [[60,60,"\"something bad\"",62,62]],
+    Exp6 = "An unknown error was encountered. Run with DEBUG=1 for more details.",
     ?assertEqual(Exp6, rebar3_hex_docs:format_error(<<"something bad">>)).

--- a/test/rebar3_hex_user_SUITE.erl
+++ b/test/rebar3_hex_user_SUITE.erl
@@ -47,7 +47,7 @@ format_error_test(_Config) ->
                  list_to_bitstring(rebar3_hex_user:format_error(no_match_local_password))),
     ?assertEqual(<<"Command must be one of register, whoami, auth, deauth or reset_password">>,
                  list_to_bitstring(rebar3_hex_user:format_error(bad_command))),
-    ?assertEqual(["'eh?'"], rebar3_hex_user:format_error('eh?')).
+    ?assertEqual("An unknown error was encountered. Run with DEBUG=1 for more details.", rebar3_hex_user:format_error('eh?')).
 
 
 


### PR DESCRIPTION
 - adjust format_error/1 catch all to return an informative message on
 how to get a data dump (i.e., DEBUG=1) vs returning that for printing
 by default