### PR TITLE
add support for configuring docs provider

### DIFF
--- a/src/rebar3_hex_docs.erl
+++ b/src/rebar3_hex_docs.erl
@@ -192,7 +192,7 @@ maybe_post_process({shell, [{cmd, Cmd}, {args, Args}]}) ->
     rebar_utils:sh(Cmd2, [{use_stdout, true}, debug_and_abort_on_error]);
 maybe_post_process({shell, Cmd}) ->
     rebar_utils:sh(post_proc_cmd(Cmd), [{use_stdout, true}, debug_and_abort_on_error]);
-maybe_post_process(Eh) ->
+maybe_post_process(_) ->
     ok.
 
 post_proc_cmd(Cmd) ->

--- a/src/rebar3_hex_docs.erl
+++ b/src/rebar3_hex_docs.erl
@@ -160,17 +160,14 @@ resolve_doc_dir(AppInfo) ->
 maybe_gen_docs(State) ->
     case doc_opts(State) of
         {ok, {PrvName, Opts}} ->
-            AllProviders = rebar_state:providers(State),
-            case providers:get_provider(PrvName, AllProviders) of
+            case providers:get_provider(PrvName, rebar_state:providers(State)) of
                 not_found ->
-                    rebar_api:error("No provider found for ~ts", [PrvName]),
-                    noop;
+                    rebar_api:error("No provider found for ~ts", [PrvName]);
                 Prv ->
                     gen_docs(State, Prv, Opts)
             end;
         _ ->
-            rebar_api:error("No valid hex docs configuration found", []),
-            noop
+            rebar_api:error("No valid hex docs configuration found", [])
     end.
 
 gen_docs(State, Prv, Opts) ->
@@ -193,7 +190,7 @@ maybe_post_process({shell, [{cmd, Cmd}, {args, Args}]}) ->
     Cmd1 = post_proc_cmd_path(Cmd),
     Cmd2 = rebar_string:join([Cmd1, rebar_string:join(Args, " ")], " "),
     do_sh(Cmd2);
-maybe_post_process({shell, Cmd}) ->
+maybe_post_process({shell, Cmd}) when is_binary(Cmd) or is_list(Cmd) ->
     do_sh(post_proc_cmd_path(Cmd));
 maybe_post_process(_) ->
     ok.

--- a/src/rebar3_hex_docs.erl
+++ b/src/rebar3_hex_docs.erl
@@ -194,12 +194,12 @@ maybe_post_process(_) -> ok.
 doc_opts(State) ->
     Opts = rebar_state:opts(State),
     case proplists:get_value(doc, rebar_opts:get(Opts, hex), undefined) of
+        undefined ->
+            undefined;
         PrvName when is_atom(PrvName) ->
             {ok, PrvName, []};
         {PrvName, DocOpts} when is_atom(PrvName) andalso is_list(DocOpts) ->
             {ok, {PrvName, DocOpts}};
-        undefined ->
-            undefined;
         _ ->
             %% Any other data type or structure is currently not supported.
             undefined

--- a/src/rebar3_hex_docs.erl
+++ b/src/rebar3_hex_docs.erl
@@ -197,8 +197,7 @@ doc_opts(State) ->
             {ok, {PrvName, DocOpts}};
         undefined ->
             undefined;
-        Eh ->
-            erlang:display(Eh),
+        _ ->
             %% Any other data type or structure is currently not supported.
             undefined
     end.

--- a/src/rebar3_hex_docs.erl
+++ b/src/rebar3_hex_docs.erl
@@ -166,21 +166,24 @@ maybe_gen_docs(State) ->
                     rebar_api:error("No provider found for ~ts", [PrvName]),
                     noop;
                 Prv ->
-                    case providers:do(Prv, State) of
-                        {ok, State} ->
-                            case proplists:get_value(post_process, Opts, undefined) of
-                                undefined ->
-                                    ok;
-                                PostOpts ->
-                                    maybe_post_process(PostOpts)
-                            end;
-                        Err ->
-                            ?PRV_ERROR({publish, Err})
-                    end
+                    gen_docs(State, Prv, Opts)
             end;
         _ ->
             rebar_api:error("No valid hex docs configuration found", []),
             noop
+    end.
+
+gen_docs(State, Prv, Opts) ->
+    case providers:do(Prv, State) of
+        {ok, State} ->
+            case proplists:get_value(post_process, Opts, undefined) of
+                undefined ->
+                    ok;
+                PostOpts ->
+                    maybe_post_process(PostOpts)
+            end;
+        Err ->
+            ?PRV_ERROR({publish, Err})
     end.
 
 maybe_post_process({shell, Cmd}) ->

--- a/src/rebar3_hex_docs.erl
+++ b/src/rebar3_hex_docs.erl
@@ -189,8 +189,10 @@ gen_docs(State, Prv, Opts) ->
 maybe_post_process({shell, [{cmd, Cmd}, {args, Args}]}) ->
     Cmd1 = post_proc_cmd(Cmd),
     Cmd2 = Cmd1 ++ " " ++ string:join(Args, " "),
+    erlang:display(Cmd2),
     rebar_utils:sh(Cmd2, [{use_stdout, true}, debug_and_abort_on_error]);
 maybe_post_process({shell, Cmd}) ->
+    erlang:display(Cmd),
     rebar_utils:sh(post_proc_cmd(Cmd), [{use_stdout, true}, debug_and_abort_on_error]);
 maybe_post_process(_) ->
     ok.

--- a/src/rebar3_hex_docs.erl
+++ b/src/rebar3_hex_docs.erl
@@ -157,6 +157,26 @@ resolve_doc_dir(AppInfo) ->
     Dir = proplists:get_value(dir, EdocOpts, ?DEFAULT_DOC_DIR),
     proplists:get_value(doc, AppDetails, Dir).
 
+%% @doc Generates docs based on configuration
+%%
+%% This function will generate a docs according to the following configuration:
+%%
+%%   - `{doc, Provider}' where `Provider' is a rebar3 provider such as `edoc'
+%%   - `{doc, {Provider, Options}}' where `Options' is a property list.
+%%
+%%  Currently we support the following options:
+%%
+%%  - `post_process' - This option should be used to indicate the user wants to
+%%    execute a command after the doc provider has successfully run. The only supported
+%%    `post_process' options at this time is the `shell' option described below
+%%
+%%
+%%  Currently supported `post_process' options :
+%%    - `shell' : The `shell' option may take one of two forms. Either
+%%    `{shell, "cmd"}' or `{shell, [{cmd, "cmd"}, {args, ["arg1", "arg2"]}]}'
+%%    We attempt to find the executable on the users PATH, if not found we assume
+%%    the command is a file in the CWD (normally the root of a users app).
+%%
 maybe_gen_docs(State) ->
     case doc_opts(State) of
         {ok, {PrvName, Opts}} ->
@@ -190,7 +210,7 @@ maybe_post_process({shell, [{cmd, Cmd}, {args, Args}]}) ->
     Cmd1 = post_proc_cmd_path(Cmd),
     Cmd2 = rebar_string:join([Cmd1, rebar_string:join(Args, " ")], " "),
     do_sh(Cmd2);
-maybe_post_process({shell, Cmd}) when is_binary(Cmd) or is_list(Cmd) ->
+maybe_post_process({shell, Cmd}) when is_list(Cmd) ->
     do_sh(post_proc_cmd_path(Cmd));
 maybe_post_process(_) ->
     ok.

--- a/src/rebar3_hex_docs.erl
+++ b/src/rebar3_hex_docs.erl
@@ -191,7 +191,7 @@ maybe_post_process({shell, undefined}) ->
     ok;
 maybe_post_process({shell, [{cmd, Cmd}, {args, Args}]}) ->
     Cmd1 = post_proc_cmd_path(Cmd),
-    Cmd2 = Cmd1 ++ " " ++ string:join(Args, " "),
+    Cmd2 = rebar_string:join([Cmd1, rebar_string:join(Args, " ")], " "),
     do_sh(Cmd2);
 maybe_post_process({shell, Cmd}) ->
     do_sh(post_proc_cmd_path(Cmd));

--- a/src/rebar3_hex_docs.erl
+++ b/src/rebar3_hex_docs.erl
@@ -164,14 +164,14 @@ resolve_doc_dir(AppInfo) ->
 %%   - `{doc, Provider}' where `Provider' is a rebar3 provider such as `edoc'
 %%   - `{doc, {Provider, Options}}' where `Options' is a property list.
 %%
-%%  Currently we support the following options:
+%%  Supported options:
 %%
 %%  - `post_process' - This option should be used to indicate the user wants to
 %%    execute a command after the doc provider has successfully run. The only supported
 %%    `post_process' options at this time is the `shell' option described below
 %%
 %%
-%%  Currently supported `post_process' options :
+%%  Supported `post_process' options :
 %%    - `shell' : The `shell' option may take one of two forms. Either
 %%    `{shell, "cmd"}' or `{shell, [{cmd, "cmd"}, {args, ["arg1", "arg2"]}]}'
 %%    We attempt to find the executable on the users PATH, if not found we assume

--- a/src/rebar3_hex_docs.erl
+++ b/src/rebar3_hex_docs.erl
@@ -186,10 +186,20 @@ gen_docs(State, Prv, Opts) ->
             ?PRV_ERROR({publish, Err})
     end.
 
+maybe_post_process({shell, [{cmd, Cmd}, {args, Args}]}) ->
+    Cmd1 = post_proc_cmd(Cmd),
+    Cmd2 = Cmd1 ++ " " ++ string:join(Args, " "),
+    rebar_utils:sh(Cmd2, [{use_stdout, true}, debug_and_abort_on_error]);
 maybe_post_process({shell, Cmd}) ->
-    AbsCmd = filename:absname(Cmd),
-    rebar_utils:sh(AbsCmd, [use_stdout]);
-maybe_post_process(_) -> ok.
+    rebar_utils:sh(post_proc_cmd(Cmd), [{use_stdout, true}, debug_and_abort_on_error]);
+maybe_post_process(Eh) ->
+    ok.
+
+post_proc_cmd(Cmd) ->
+    case rebar_utils:find_executable(Cmd) of
+        false -> filename:absname(Cmd);
+        Path -> Path
+    end.
 
 doc_opts(State) ->
     Opts = rebar_state:opts(State),

--- a/test/rebar3_hex_integration_SUITE.erl
+++ b/test/rebar3_hex_integration_SUITE.erl
@@ -132,35 +132,39 @@ docs_post_process_test(Config) ->
     P = #{app => "valid", mocks => [docs]},
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
     Command = ["docs"],
-    RepoConfig =  [{repos,[Repo]}, {docs, {edoc, [{post_process, [{shell, "echo"}]}]}}],
+    RepoConfig =  [{repos,[Repo]}, {doc, {edoc, [{post_process, [{shell, "echo"}]}]}}],
     {ok, DocState} = test_utils:mock_command(rebar3_hex_docs, Command, RepoConfig, State),
-    ?assertMatch({ok, DocState}, rebar3_hex_docs:do(DocState)).
+    {ok, NewState} = rebar_prv_edoc:init(DocState),
+    ?assertMatch({ok, NewState}, rebar3_hex_docs:do(NewState)).
 
 docs_post_process_error_test(Config) ->
     P = #{app => "valid", mocks => [docs]},
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
     Command = ["docs"],
-    RepoConfig =  [{repos,[Repo]}, {docs, {edoc, [{post_process, [{shell, "eh?"}]}]}}],
+    RepoConfig =  [{repos,[Repo]}, {doc, {edoc, [{post_process, [{shell, "eh?"}]}]}}],
     {ok, DocState} = test_utils:mock_command(rebar3_hex_docs, Command, RepoConfig, State),
-    ?assertThrow(rebar_abort, rebar3_hex_docs:do(DocState)).
+    {ok, NewState} = rebar_prv_edoc:init(DocState),
+    ?assertThrow(rebar_abort, rebar3_hex_docs:do(NewState)).
 
 docs_post_process_with_args_test(Config) ->
     P = #{app => "valid", mocks => [docs]},
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
     Command = ["docs"],
-    PostProc = [{post_process, {shell, [{cmd, "echo"}, {args,["this","that","foo","bar"]}]}}],
-    RepoConfig =  [{repos,[Repo]}, {docs, {edoc, [PostProc]}}],
+    PostProc = [{post_process, [{shell, [{cmd, "echo"}, {args,["this","that","foo","bar"]}]}]}],
+    RepoConfig =  [{repos,[Repo]}, {doc, {edoc, PostProc}}],
     {ok, DocState} = test_utils:mock_command(rebar3_hex_docs, Command, RepoConfig, State),
-    ?assertMatch({ok, DocState}, rebar3_hex_docs:do(DocState)).
+    {ok, NewState} = rebar_prv_edoc:init(DocState),
+    ?assertMatch({ok, NewState}, rebar3_hex_docs:do(NewState)).
 
 docs_post_process_with_args_error_test(Config) ->
     P = #{app => "valid", mocks => [docs]},
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
     Command = ["docs"],
-    PostProc = {post_process, {shell, [{cmd, "eh?"}, {args,["this","that","foo","bar"]}]}},
-    RepoConfig =  [{repos,[Repo]}, {docs, {edoc, [PostProc]}}],
+    PostProc = {post_process, [{shell, [{cmd, "eh?"}, {args,["this","that","foo","bar"]}]}]},
+    RepoConfig =  [{repos,[Repo]}, {doc, {edoc, [PostProc]}}],
     {ok, DocState} = test_utils:mock_command(rebar3_hex_docs, Command, RepoConfig, State),
-    ?assertThrow(rebar_abort, rebar3_hex_docs:do(DocState)).
+    {ok, NewState} = rebar_prv_edoc:init(DocState),
+    ?assertThrow(rebar_abort, rebar3_hex_docs:do(NewState)).
 
 docs_dir_error_test(Config) ->
     P = #{app => "valid", mocks => [docs]},

--- a/test/rebar3_hex_integration_SUITE.erl
+++ b/test/rebar3_hex_integration_SUITE.erl
@@ -13,10 +13,6 @@ all() ->
     , decrypt_write_key_test
     , bad_command_test
     , docs_test
-    , docs_post_process_test
-    , docs_post_process_error_test
-    , docs_post_process_with_args_test
-    , docs_post_process_with_args_error_test
     , docs_auth_error_test
     , docs_dir_error_test
     , docs_invalid_repo_test
@@ -127,44 +123,6 @@ docs_test(Config) ->
     {ok, DocState} = test_utils:mock_command(rebar3_hex_docs, Command, RepoConfig, State),
     {ok, NewState} = rebar_prv_edoc:do(DocState),
     ?assertMatch({ok, NewState}, rebar3_hex_docs:do(NewState)).
-
-docs_post_process_test(Config) ->
-    P = #{app => "valid", mocks => [docs]},
-    {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
-    Command = ["docs"],
-    RepoConfig =  [{repos,[Repo]}, {doc, #{provider => edoc, post_process =>  [{shell, "echo"}]}}],
-    {ok, DocState} = test_utils:mock_command(rebar3_hex_docs, Command, RepoConfig, State),
-    {ok, NewState} = rebar_prv_edoc:init(DocState),
-    ?assertMatch({ok, NewState}, rebar3_hex_docs:do(NewState)).
-
-docs_post_process_error_test(Config) ->
-    P = #{app => "valid", mocks => [docs]},
-    {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
-    Command = ["docs"],
-    RepoConfig =  [{repos,[Repo]}, {doc, #{provider => edoc, post_process => [{shell, "eh?"}]}}],
-    {ok, DocState} = test_utils:mock_command(rebar3_hex_docs, Command, RepoConfig, State),
-    {ok, NewState} = rebar_prv_edoc:init(DocState),
-    ?assertThrow(rebar_abort, rebar3_hex_docs:do(NewState)).
-
-docs_post_process_with_args_test(Config) ->
-    P = #{app => "valid", mocks => [docs]},
-    {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
-    Command = ["docs"],
-    PostProc = [{shell, #{cmd => "echo", args => ["this","that","foo","bar"]}}],
-    RepoConfig =  [{repos,[Repo]}, {doc, #{provider => edoc, post_process => PostProc}}],
-    {ok, DocState} = test_utils:mock_command(rebar3_hex_docs, Command, RepoConfig, State),
-    {ok, NewState} = rebar_prv_edoc:init(DocState),
-    ?assertMatch({ok, NewState}, rebar3_hex_docs:do(NewState)).
-
-docs_post_process_with_args_error_test(Config) ->
-    P = #{app => "valid", mocks => [docs]},
-    {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
-    Command = ["docs"],
-    PostProc = [{shell, #{cmd => "eh?", args => ["this","that","foo","bar"]}}],
-    RepoConfig =  [{repos,[Repo]}, {doc, #{provider => edoc, post_process => PostProc}}],
-    {ok, DocState} = test_utils:mock_command(rebar3_hex_docs, Command, RepoConfig, State),
-    {ok, NewState} = rebar_prv_edoc:init(DocState),
-    ?assertThrow(rebar_abort, rebar3_hex_docs:do(NewState)).
 
 docs_dir_error_test(Config) ->
     P = #{app => "valid", mocks => [docs]},

--- a/test/rebar3_hex_integration_SUITE.erl
+++ b/test/rebar3_hex_integration_SUITE.erl
@@ -132,7 +132,7 @@ docs_post_process_test(Config) ->
     P = #{app => "valid", mocks => [docs]},
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
     Command = ["docs"],
-    RepoConfig =  [{repos,[Repo]}, {doc, {edoc, [{post_process, [{shell, "echo"}]}]}}],
+    RepoConfig =  [{repos,[Repo]}, {doc, #{provider => edoc, post_process =>  [{shell, "echo"}]}}],
     {ok, DocState} = test_utils:mock_command(rebar3_hex_docs, Command, RepoConfig, State),
     {ok, NewState} = rebar_prv_edoc:init(DocState),
     ?assertMatch({ok, NewState}, rebar3_hex_docs:do(NewState)).
@@ -141,7 +141,7 @@ docs_post_process_error_test(Config) ->
     P = #{app => "valid", mocks => [docs]},
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
     Command = ["docs"],
-    RepoConfig =  [{repos,[Repo]}, {doc, {edoc, [{post_process, [{shell, "eh?"}]}]}}],
+    RepoConfig =  [{repos,[Repo]}, {doc, #{provider => edoc, post_process => [{shell, "eh?"}]}}],
     {ok, DocState} = test_utils:mock_command(rebar3_hex_docs, Command, RepoConfig, State),
     {ok, NewState} = rebar_prv_edoc:init(DocState),
     ?assertThrow(rebar_abort, rebar3_hex_docs:do(NewState)).
@@ -150,8 +150,8 @@ docs_post_process_with_args_test(Config) ->
     P = #{app => "valid", mocks => [docs]},
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
     Command = ["docs"],
-    PostProc = [{post_process, [{shell, [{cmd, "echo"}, {args,["this","that","foo","bar"]}]}]}],
-    RepoConfig =  [{repos,[Repo]}, {doc, {edoc, PostProc}}],
+    PostProc = [{shell, #{cmd => "echo", args => ["this","that","foo","bar"]}}],
+    RepoConfig =  [{repos,[Repo]}, {doc, #{provider => edoc, post_process => PostProc}}],
     {ok, DocState} = test_utils:mock_command(rebar3_hex_docs, Command, RepoConfig, State),
     {ok, NewState} = rebar_prv_edoc:init(DocState),
     ?assertMatch({ok, NewState}, rebar3_hex_docs:do(NewState)).
@@ -160,8 +160,8 @@ docs_post_process_with_args_error_test(Config) ->
     P = #{app => "valid", mocks => [docs]},
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
     Command = ["docs"],
-    PostProc = {post_process, [{shell, [{cmd, "eh?"}, {args,["this","that","foo","bar"]}]}]},
-    RepoConfig =  [{repos,[Repo]}, {doc, {edoc, [PostProc]}}],
+    PostProc = [{shell, #{cmd => "eh?", args => ["this","that","foo","bar"]}}],
+    RepoConfig =  [{repos,[Repo]}, {doc, #{provider => edoc, post_process => PostProc}}],
     {ok, DocState} = test_utils:mock_command(rebar3_hex_docs, Command, RepoConfig, State),
     {ok, NewState} = rebar_prv_edoc:init(DocState),
     ?assertThrow(rebar_abort, rebar3_hex_docs:do(NewState)).

--- a/test/rebar3_hex_integration_SUITE.erl
+++ b/test/rebar3_hex_integration_SUITE.erl
@@ -13,6 +13,8 @@ all() ->
     , decrypt_write_key_test
     , bad_command_test
     , docs_test
+    , docs_post_process_simple_test
+    , docs_post_process_simple_error_test
     , docs_auth_error_test
     , docs_dir_error_test
     , docs_invalid_repo_test
@@ -119,7 +121,26 @@ docs_test(Config) ->
     P = #{app => "valid", mocks => [docs]},
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
     Command = ["docs"],
-    {ok, DocState} = test_utils:mock_command(rebar3_hex_docs, Command, Repo, State),
+    RepoConfig =  [{repos,[Repo]}],
+    {ok, DocState} = test_utils:mock_command(rebar3_hex_docs, Command, RepoConfig, State),
+    {ok, NewState} = rebar_prv_edoc:do(DocState),
+    ?assertMatch({ok, NewState}, rebar3_hex_docs:do(NewState)).
+
+docs_post_process_simple_test(Config) ->
+    P = #{app => "valid", mocks => [docs]},
+    {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
+    Command = ["docs"],
+    RepoConfig =  [{repos,[Repo]}, {docs, {edoc, [{post_process, [{cmd, "echo eh?"}]}]}}],
+    {ok, DocState} = test_utils:mock_command(rebar3_hex_docs, Command, RepoConfig, State),
+    {ok, NewState} = rebar_prv_edoc:do(DocState),
+    ?assertMatch({ok, NewState}, rebar3_hex_docs:do(NewState)).
+
+docs_post_process_simple_error_test(Config) ->
+    P = #{app => "valid", mocks => [docs]},
+    {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
+    Command = ["docs"],
+    RepoConfig =  [{repos,[Repo]}, {docs, {edoc, [{post_process, [{shell, "eh?"}]}]}}],
+    {ok, DocState} = test_utils:mock_command(rebar3_hex_docs, Command, RepoConfig, State),
     {ok, NewState} = rebar_prv_edoc:do(DocState),
     ?assertMatch({ok, NewState}, rebar3_hex_docs:do(NewState)).
 
@@ -127,14 +148,16 @@ docs_dir_error_test(Config) ->
     P = #{app => "valid", mocks => [docs]},
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
     Command = ["docs"],
-    {ok, NewState} = test_utils:mock_command(rebar3_hex_docs, Command, Repo, State),
+    RepoConfig = [{repos,[Repo]}],
+    {ok, NewState} = test_utils:mock_command(rebar3_hex_docs, Command, RepoConfig, State),
     ?assertThrow(rebar_abort, rebar3_hex_docs:do(NewState)).
 
 docs_revert_test(Config) ->
     P = #{app => "valid", mocks => [docs]},
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
     Command = ["revert", "0.1.1"],
-    {ok, DocState} = test_utils:mock_command(rebar3_hex_docs, Command, Repo, State),
+    RepoConfig =  [{repos,[Repo]}],
+    {ok, DocState} = test_utils:mock_command(rebar3_hex_docs, Command, RepoConfig, State),
     {ok, NewState} = rebar_prv_edoc:do(DocState),
     ?assertMatch({ok, NewState}, rebar3_hex_docs:do(NewState)).
 
@@ -148,7 +171,8 @@ docs_revert_auth_error_test(Config) ->
          },
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
     Command = ["revert", "0.1.1"],
-    {ok, DocState} = test_utils:mock_command(rebar3_hex_docs, Command, Repo, State),
+    RepoConfig = [{repos,[Repo]}],
+    {ok, DocState} = test_utils:mock_command(rebar3_hex_docs, Command, RepoConfig, State),
     %ExpError = {error,{rebar3_hex_docs,{revert,{unauthorized,#{}}}}},
     ExpError = {error,{rebar3_hex_docs,{publish,{error,#{}}}}},
     {ok, NewState} = rebar_prv_edoc:do(DocState),
@@ -164,7 +188,8 @@ docs_auth_error_test(Config) ->
          },
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
     Command = [],
-    {ok, DocState} = test_utils:mock_command(rebar3_hex_docs, Command, Repo, State),
+    RepoConfig =  [{repos,[Repo]}],
+    {ok, DocState} = test_utils:mock_command(rebar3_hex_docs, Command, RepoConfig, State),
     {ok, NewState} = rebar_prv_edoc:do(DocState),
     ExpError = {error,{rebar3_hex_docs,{publish,{error,#{}}}}},
     ?assertMatch(ExpError , rebar3_hex_docs:do(NewState)).
@@ -179,7 +204,8 @@ docs_invalid_repo_test(Config) ->
 
          },
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
-    {ok, DocState} = test_utils:mock_command(rebar3_hex_docs, ["-r", "hexpm:valid"], Repo, State),
+    RepoConfig =  [{repos,[Repo]}],
+    {ok, DocState} = test_utils:mock_command(rebar3_hex_docs, ["-r", "hexpm:valid"], RepoConfig, State),
     {ok, NewState} = rebar_prv_edoc:do(DocState),
 
     ExpError = {error,{rebar3_hex_docs,{not_valid_repo,"hexpm:valid"}}},
@@ -191,7 +217,8 @@ docs_no_write_key_test(Config) ->
           repo_config => #{write_key => undefined}
          },
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
-    {ok, DocState} = test_utils:mock_command(rebar3_hex_docs, [], Repo, State),
+    RepoConfig =  [{repos,[Repo]}],
+    {ok, DocState} = test_utils:mock_command(rebar3_hex_docs, [], RepoConfig, State),
     {ok, NewState} = rebar_prv_edoc:do(DocState),
 
     ExpError = {error,{rebar3_hex_docs,no_write_key}},
@@ -223,8 +250,8 @@ register_user_test(Config) ->
           email => <<"jlundegaard@gustafson-mortors.com">>
          },
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
-
-    {ok, RegState} = test_utils:mock_command(rebar3_hex_user, ["register"], Repo, State),
+    RepoConfig =  [{repos,[Repo]}],
+    {ok, RegState} = test_utils:mock_command(rebar3_hex_user, ["register"], RepoConfig, State),
     ?assertMatch({ok, RegState}, rebar3_hex_user:do(RegState)).
 
 register_existing_user_test(Config) ->
@@ -236,8 +263,8 @@ register_existing_user_test(Config) ->
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
     create_user(?default_username, ?default_password, ?default_email, Repo),
     ExpErr1 = {error, {rebar3_hex_user, {registration_failure, <<"email already in use">>}}},
-
-    {ok, RegState} = test_utils:mock_command(rebar3_hex_user, ["register"], Repo, State),
+    RepoConfig = [{repos,[Repo]}],
+    {ok, RegState} = test_utils:mock_command(rebar3_hex_user, ["register"], RepoConfig, State),
     ?assertMatch(ExpErr1, rebar3_hex_user:do(RegState)).
 
 register_empty_password_test(Config) ->
@@ -246,7 +273,8 @@ register_empty_password_test(Config) ->
           password => <<>>
          },
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
-    {ok, AuthState} = test_utils:mock_command(rebar3_hex_user, ["register"], Repo, State),
+    RepoConfig =  [{repos,[Repo]}],
+    {ok, AuthState} = test_utils:mock_command(rebar3_hex_user, ["register"], RepoConfig, State),
 
     ?assertMatch(error, rebar3_hex_user:do(AuthState)).
 
@@ -254,7 +282,8 @@ register_error_test(Config) ->
     meck:expect(hex_api_user, create, fun(_,_,_,_) -> {error, meh} end),
     P = #{app => "valid", mocks => [register]},
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
-    {ok, AuthState} = test_utils:mock_command(rebar3_hex_user, ["register"], Repo, State),
+    RepoConfig = [{repos,[Repo]}],
+    {ok, AuthState} = test_utils:mock_command(rebar3_hex_user, ["register"], RepoConfig, State),
 
     ExpErr = {error,{rebar3_hex_user,{registration_failure,["meh"]}}},
     ?assertMatch(ExpErr, rebar3_hex_user:do(AuthState)).
@@ -263,7 +292,8 @@ register_password_mismatch_test(Config) ->
     P = #{app => "valid", mocks => [register], password_confirmation => <<"special_shoes0">>},
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
     create_user(?default_username, ?default_password, ?default_email, Repo),
-    {ok, AuthState} = test_utils:mock_command(rebar3_hex_user, ["register"], Repo, State),
+    RepoConfig = [{repos,[Repo]}],
+    {ok, AuthState} = test_utils:mock_command(rebar3_hex_user, ["register"], RepoConfig, State),
 
     ExpErr = {error,{rebar3_hex_user,{error,"passwords do not match"}}},
     ?assertMatch(ExpErr, rebar3_hex_user:do(AuthState)).
@@ -272,14 +302,16 @@ auth_test(Config) ->
     P = #{app => "valid", mocks => [first_auth]},
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
     create_user(?default_username, ?default_password, ?default_email, Repo),
-    {ok, AuthState} = test_utils:mock_command(rebar3_hex_user, ["auth"], Repo, State),
+    RepoConfig = [{repos,[Repo]}],
+    {ok, AuthState} = test_utils:mock_command(rebar3_hex_user, ["auth"], RepoConfig, State),
     ?assertMatch({ok, AuthState}, rebar3_hex_user:do(AuthState)).
 
 auth_bad_local_password_test(Config) ->
     P = #{app => "valid", mocks => [first_auth], password_confirmation => <<"oops">>},
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
     create_user(?default_username, ?default_password, ?default_email, Repo),
-    {ok, AuthState} = test_utils:mock_command(rebar3_hex_user, ["auth"], Repo, State),
+    RepoConfig = [{repos,[Repo]}],
+    {ok, AuthState} = test_utils:mock_command(rebar3_hex_user, ["auth"], RepoConfig, State),
     ?assertThrow({error,{rebar3_hex_user,no_match_local_password}}, rebar3_hex_user:do(AuthState)).
 
 auth_password_24_char_test(Config) ->
@@ -287,7 +319,8 @@ auth_password_24_char_test(Config) ->
     P = #{app => "valid", mocks => [first_auth], password => Pass, password_confirmation => Pass},
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
     create_user(?default_username, ?default_password, ?default_email, Repo),
-    {ok, AuthState} = test_utils:mock_command(rebar3_hex_user, ["auth"], Repo, State),
+    RepoConfig = [{repos,[Repo]}],
+    {ok, AuthState} = test_utils:mock_command(rebar3_hex_user, ["auth"], RepoConfig, State),
     ?assertMatch({ok, AuthState}, rebar3_hex_user:do(AuthState)).
 
 auth_password_32_char_test(Config) ->
@@ -295,7 +328,8 @@ auth_password_32_char_test(Config) ->
     P = #{app => "valid", mocks => [first_auth], password => Pass, password_confirmation => Pass},
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
     create_user(?default_username, ?default_password, ?default_email, Repo),
-    {ok, AuthState} = test_utils:mock_command(rebar3_hex_user, ["auth"], Repo, State),
+    RepoConfig = [{repos,[Repo]}],
+    {ok, AuthState} = test_utils:mock_command(rebar3_hex_user, ["auth"], RepoConfig, State),
     ?assertMatch({ok, AuthState}, rebar3_hex_user:do(AuthState)).
 
 auth_unhandled_test(Config) ->
@@ -306,7 +340,8 @@ auth_unhandled_test(Config) ->
 
     P = #{app => "valid", mocks => [first_auth]},
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
-    {ok, AuthState} = test_utils:mock_command(rebar3_hex_user, ["auth"], Repo, State),
+    RepoConfig = [{repos,[Repo]}],
+    {ok, AuthState} = test_utils:mock_command(rebar3_hex_user, ["auth"], RepoConfig, State),
 
     ExpErr = {error,{rebar3_hex_user,{generate_key,<<"eh?">>}}},
     ?assertMatch(ExpErr, rebar3_hex_user:do(AuthState)),
@@ -319,7 +354,8 @@ auth_error_test(Config) ->
 
     P = #{app => "valid", mocks => [first_auth]},
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
-    {ok, AuthState} = test_utils:mock_command(rebar3_hex_user, ["auth"], Repo, State),
+    RepoConfig = [{repos,[Repo]}],
+    {ok, AuthState} = test_utils:mock_command(rebar3_hex_user, ["auth"], RepoConfig, State),
 
     ExpErr = {error,{rebar3_hex_user,{generate_key,["meh"]}}},
     ?assertMatch(ExpErr, rebar3_hex_user:do(AuthState)),
@@ -328,14 +364,16 @@ auth_error_test(Config) ->
 whoami_test(Config) ->
     P = #{app => "valid", mocks => [whoami]},
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
-    {ok, WhoamiState} = test_utils:mock_command(rebar3_hex_user, ["whoami"], Repo, State),
+    RepoConfig = [{repos,[Repo]}],
+    {ok, WhoamiState} = test_utils:mock_command(rebar3_hex_user, ["whoami"], RepoConfig, State),
 
     ?assertMatch({ok, WhoamiState}, rebar3_hex_user:do(WhoamiState)).
 
 whoami_unknown_test(Config) ->
     P = #{app => "valid", mocks => [whoami], repo_config => #{read_key => <<"eh?">>}},
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
-    {ok, WhoamiState} = test_utils:mock_command(rebar3_hex_user, ["whoami"], Repo, State),
+    RepoConfig = [{repos,[Repo]}],
+    {ok, WhoamiState} = test_utils:mock_command(rebar3_hex_user, ["whoami"], RepoConfig, State),
 
     ExpErr = {error,{rebar3_hex_user,{whoami_failure,<<"huh?">>}}},
     ?assertMatch(ExpErr, rebar3_hex_user:do(WhoamiState)).
@@ -356,7 +394,8 @@ whoami_api_error_test(Config) ->
     meck:expect(hex_api_user, me, fun(_) -> {error, meh} end),
     P = #{app => "valid", mocks => [whoami], repo_config => #{read_key => <<"!">>}},
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
-    {ok, WhoamiState} = test_utils:mock_command(rebar3_hex_user, ["whoami"], Repo, State),
+    RepoConfig = [{repos,[Repo]}],
+    {ok, WhoamiState} = test_utils:mock_command(rebar3_hex_user, ["whoami"], RepoConfig, State),
 
     ExpErr = {error,{rebar3_hex_user,{whoami_failure,["meh"]}}},
     ?assertMatch(ExpErr, rebar3_hex_user:do(WhoamiState)).
@@ -365,7 +404,8 @@ whoami_error_test(Config) ->
     meck:expect(hex_api_user, me, fun(_) -> {error, meh} end),
     P = #{app => "valid", mocks => [whoami]},
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
-    {ok, WhoamiState} = test_utils:mock_command(rebar3_hex_user, ["whoami"], Repo, State),
+    RepoConfig = [{repos,[Repo]}],
+    {ok, WhoamiState} = test_utils:mock_command(rebar3_hex_user, ["whoami"], RepoConfig, State),
 
     ExpErr = {error,{rebar3_hex_user,{whoami_failure,["meh"]}}},
     ?assertMatch(ExpErr, rebar3_hex_user:do(WhoamiState)).
@@ -375,7 +415,8 @@ whoami_not_authed_test(Config) ->
     expects_output([Str]),
     P = #{app => "valid", mocks => [whoami], repo_config => #{read_key => undefined}},
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
-    {ok, WhoamiState } = test_utils:mock_command(rebar3_hex_user, ["whoami"], Repo, State),
+    RepoConfig = [{repos,[Repo]}],
+    {ok, WhoamiState } = test_utils:mock_command(rebar3_hex_user, ["whoami"], RepoConfig, State),
 
     ExpErr = {error,"Not authenticated as any user currently for this repository"},
     ?assertMatch(ExpErr, rebar3_hex_user:do(WhoamiState)),
@@ -384,7 +425,8 @@ whoami_not_authed_test(Config) ->
 reset_password_test(Config) ->
     P = #{app => "valid", mocks => [reset_password], username => "mr_pockets"},
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
-    {ok, ResetState} = test_utils:mock_command(rebar3_hex_user, ["reset_password"], Repo, State),
+    RepoConfig = [{repos,[Repo]}],
+    {ok, ResetState} = test_utils:mock_command(rebar3_hex_user, ["reset_password"], RepoConfig, State),
 
     ?assertMatch({ok, ResetState}, rebar3_hex_user:do(ResetState)).
 
@@ -392,7 +434,8 @@ reset_password_test(Config) ->
 reset_password_api_error_test(Config) ->
     P = #{app => "valid", mocks => [reset_password], username => "eh?", repo_config => #{username => "eh?"}},
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
-    {ok, ResetState} = test_utils:mock_command(rebar3_hex_user, ["reset_password"], Repo, State),
+    RepoConfig = [{repos,[Repo]}],
+    {ok, ResetState} = test_utils:mock_command(rebar3_hex_user, ["reset_password"], RepoConfig, State),
 
     ExpErr = {error,{rebar3_hex_user,{reset_failure,<<"huh?">>}}},
     ?assertMatch(ExpErr, rebar3_hex_user:do(ResetState)).
@@ -412,7 +455,8 @@ reset_password_error_test(Config) ->
     meck:expect(hex_api_user, reset_password, fun(_,_) -> {error, meh} end),
     P = #{app => "valid", mocks => [reset_password], username => "mr_pockets"},
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
-    {ok, ResetState} = test_utils:mock_command(rebar3_hex_user, ["reset_password"], Repo, State),
+    RepoConfig = [{repos,[Repo]}],
+    {ok, ResetState} = test_utils:mock_command(rebar3_hex_user, ["reset_password"], RepoConfig, State),
 
     ExpErr = {error,{rebar3_hex_user,{reset_failure,["meh"]}}},
     ?assertMatch(ExpErr, rebar3_hex_user:do(ResetState)).
@@ -420,14 +464,16 @@ reset_password_error_test(Config) ->
 deauth_test(Config) ->
     P = #{app => "valid", mocks => [deauth]},
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
-    {ok, DeauthState} = test_utils:mock_command(rebar3_hex_user, ["deauth"], Repo, State),
+    RepoConfig = [{repos,[Repo]}],
+    {ok, DeauthState} = test_utils:mock_command(rebar3_hex_user, ["deauth"], RepoConfig, State),
 
     ?assertMatch({ok, DeauthState}, rebar3_hex_user:do(DeauthState)).
 
 publish_test(Config) ->
     P = #{app => "valid", mocks => [publish]},
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
-    {ok, PubState} = test_utils:mock_command(rebar3_hex_publish, [], Repo, State),
+    RepoConfig = [{repos,[Repo]}],
+    {ok, PubState} = test_utils:mock_command(rebar3_hex_publish, [], RepoConfig, State),
     {ok, _} = rebar_prv_edoc:do(PubState),
 
     ?assertMatch({ok, PubState}, rebar3_hex_publish:do(PubState)).
@@ -440,7 +486,8 @@ publish_test(Config) ->
 publish_replace_test(Config) ->
     P = #{app => "valid", mocks => [publish]},
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
-    {ok, PubState} = test_utils:mock_command(rebar3_hex_publish, ["--replace"], Repo, State),
+    RepoConfig = [{repos,[Repo]}],
+    {ok, PubState} = test_utils:mock_command(rebar3_hex_publish, ["--replace"], RepoConfig, State),
     {ok, _} = rebar_prv_edoc:do(PubState),
 
     ?assertMatch({ok, PubState}, rebar3_hex_publish:do(PubState)).
@@ -448,7 +495,8 @@ publish_replace_test(Config) ->
 publish_revert_test(Config) ->
     P = #{app => "valid", mocks => [publish_revert], version => "1.0.0"},
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
-    {ok, PubState} = test_utils:mock_command(rebar3_hex_publish, ["--revert", "1.0.0", "--package", "valid"], Repo, State),
+    RepoConfig = [{repos,[Repo]}],
+    {ok, PubState} = test_utils:mock_command(rebar3_hex_publish, ["--revert", "1.0.0", "--package", "valid"], RepoConfig, State),
 
     ?assertMatch({ok, PubState}, rebar3_hex_publish:do(PubState)).
 
@@ -463,7 +511,8 @@ publish_org_test(Config) ->
                           }
          },
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
-    {ok, PubState} = test_utils:mock_command(rebar3_hex_publish, ["-r", "hexpm:valid"], Repo, State),
+    RepoConfig = [{repos,[Repo]}],
+    {ok, PubState} = test_utils:mock_command(rebar3_hex_publish, ["-r", "hexpm:valid"], RepoConfig, State),
     {ok, _} = rebar_prv_edoc:do(PubState),
 
     ?assertMatch({ok, PubState}, rebar3_hex_publish:do(PubState)).
@@ -471,7 +520,8 @@ publish_org_test(Config) ->
 publish_org_error_test(Config) ->
     P = #{app => "valid", mocks => [publish], repo_config => #{repo => <<"hexpm:foo">>, name => <<"hexpm:foo">>}},
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
-    {ok, PubState} = test_utils:mock_command(rebar3_hex_publish, ["-r", "hexpm:bar"], Repo, State),
+    RepoConfig = [{repos,[Repo]}],
+    {ok, PubState} = test_utils:mock_command(rebar3_hex_publish, ["-r", "hexpm:bar"], RepoConfig, State),
 
     ExpError = {error,{rebar3_hex_publish,{not_valid_repo,"hexpm:bar"}}},
     ?assertMatch(ExpError, rebar3_hex_publish:do(PubState)).
@@ -479,13 +529,15 @@ publish_org_error_test(Config) ->
 publish_org_requires_repo_arg_test(Config) ->
     P = #{app => "valid", mocks => [publish], repo_config => #{repo => <<"hexpm:valid">>, name => <<"hexpm:valid">>}},
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
-    {ok, PubState} = test_utils:mock_command(rebar3_hex_publish, [], Repo, State),
+    RepoConfig = [{repos,[Repo]}],
+    {ok, PubState} = test_utils:mock_command(rebar3_hex_publish, [], RepoConfig, State),
     ?assertMatch({error,{rebar3_hex_publish,{required,repo}}}, rebar3_hex_publish:do(PubState)).
 
 publish_error_test(Config) ->
     P = #{app => "valid", mocks => [publish], repo_config => #{write_key => undefined}},
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
-    {ok, PubState} = test_utils:mock_command(rebar3_hex_publish, [], Repo, State),
+    RepoConfig = [{repos,[Repo]}],
+    {ok, PubState} = test_utils:mock_command(rebar3_hex_publish, [], RepoConfig, State),
 
     ?assertMatch({error,{rebar3_hex_publish,no_write_key}}, rebar3_hex_publish:do(PubState)).
 
@@ -496,7 +548,8 @@ publish_unauthorized_test(Config) ->
           repo_config => #{write_key => WriteKey, repo => <<"hexpm:valid">>, name => <<"hexpm:valid">>}
          },
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
-    {ok, PubState} = test_utils:mock_command(rebar3_hex_publish, ["-r", "hexpm:valid"], Repo, State),
+    RepoConfig = [{repos,[Repo]}],
+    {ok, PubState} = test_utils:mock_command(rebar3_hex_publish, ["-r", "hexpm:valid"], RepoConfig, State),
     Exp = {error,
            {rebar3_hex_publish,
             {publish,
@@ -508,35 +561,40 @@ publish_unauthorized_test(Config) ->
 key_list_test(Config) ->
     P = #{app => "valid", mocks => []},
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
-    {ok, ListState} = test_utils:mock_command(rebar3_hex_key, ["list"], Repo, State),
+    RepoConfig = [{repos,[Repo]}],
+    {ok, ListState} = test_utils:mock_command(rebar3_hex_key, ["list"], RepoConfig, State),
 
     ?assertMatch({ok, ListState}, rebar3_hex_key:do(ListState)).
 
 key_get_test(Config) ->
     P = #{app => "valid", mocks => []},
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
-    {ok, GetState} = test_utils:mock_command(rebar3_hex_key, ["fetch", "-k", "key"], Repo, State),
+    RepoConfig = [{repos,[Repo]}],
+    {ok, GetState} = test_utils:mock_command(rebar3_hex_key, ["fetch", "-k", "key"], RepoConfig, State),
 
     ?assertMatch({ok, GetState}, rebar3_hex_key:do(GetState)).
 
 key_add_test(Config) ->
     P = #{app => "valid", mocks => [key_mutation]},
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
-    {ok, AddState} = test_utils:mock_command(rebar3_hex_key, ["generate", "-k", "foo"], Repo, State),
+    RepoConfig = [{repos,[Repo]}],
+    {ok, AddState} = test_utils:mock_command(rebar3_hex_key, ["generate", "-k", "foo"], RepoConfig, State),
 
     ?assertMatch({ok, AddState}, rebar3_hex_key:do(AddState)).
 
 key_delete_test(Config) ->
     P = #{app => "valid", mocks => [key_mutation]},
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
-    {ok, AddState} = test_utils:mock_command(rebar3_hex_key, ["revoke", "-k", "key"], Repo, State),
+    RepoConfig = [{repos,[Repo]}],
+    {ok, AddState} = test_utils:mock_command(rebar3_hex_key, ["revoke", "-k", "key"], RepoConfig, State),
 
     ?assertMatch({ok, AddState}, rebar3_hex_key:do(AddState)).
 
 key_delete_all_test(Config) ->
     P = #{app => "valid", mocks => [key_mutation]},
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
-    {ok, AddState} = test_utils:mock_command(rebar3_hex_key, ["revoke", "--all"], Repo, State),
+    RepoConfig = [{repos,[Repo]}],
+    {ok, AddState} = test_utils:mock_command(rebar3_hex_key, ["revoke", "--all"], RepoConfig, State),
 
     ?assertMatch({ok, AddState}, rebar3_hex_key:do(AddState)).
 
@@ -545,7 +603,8 @@ owner_add_test(Config) ->
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
     create_user(?default_username, ?default_password, ?default_email, Repo),
     Command = ["add", "truecoat", "wade@foo.bar"],
-    {ok, AddState} = test_utils:mock_command(rebar3_hex_owner, Command, Repo, State),
+    RepoConfig = [{repos,[Repo]}],
+    {ok, AddState} = test_utils:mock_command(rebar3_hex_owner, Command, RepoConfig, State),
 
     ?assertMatch({ok, AddState}, rebar3_hex_owner:do(AddState)).
 
@@ -554,7 +613,8 @@ owner_transfer_test(Config) ->
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
     create_user(?default_username, ?default_password, ?default_email, Repo),
     Command = ["transfer", "truecoat", "gustafson_motors", "-r", "hexpm"],
-    {ok, AddState} = test_utils:mock_command(rebar3_hex_owner, Command, Repo, State),
+    RepoConfig = [{repos,[Repo]}],
+    {ok, AddState} = test_utils:mock_command(rebar3_hex_owner, Command, RepoConfig, State),
 
     ?assertMatch({ok, AddState}, rebar3_hex_owner:do(AddState)).
 
@@ -563,7 +623,8 @@ owner_remove_test(Config) ->
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
     create_user(?default_username, ?default_password, ?default_email, Repo),
     Command = ["remove", "truecoat", "wade@foo.bar"],
-    {ok, RemoveState} = test_utils:mock_command(rebar3_hex_owner, Command, Repo, State),
+    RepoConfig = [{repos,[Repo]}],
+    {ok, RemoveState} = test_utils:mock_command(rebar3_hex_owner, Command, RepoConfig, State),
 
     ?assertMatch({ok, RemoveState}, rebar3_hex_owner:do(RemoveState)).
 
@@ -572,7 +633,8 @@ owner_list_test(Config) ->
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
     create_user(?default_username, ?default_password, ?default_email, Repo),
     Command = ["list", "truecoat"],
-    {ok, ListState} = test_utils:mock_command(rebar3_hex_owner, Command, Repo, State),
+    RepoConfig = [{repos,[Repo]}],
+    {ok, ListState} = test_utils:mock_command(rebar3_hex_owner, Command, RepoConfig, State),
 
     ?assertMatch({ok, ListState}, rebar3_hex_owner:do(ListState)).
 
@@ -580,7 +642,8 @@ bad_command_test(Config) ->
     P = #{app => "valid", mocks => [deauth]},
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
     Command = ["bad_command"],
-    {ok, BadcommandState} = test_utils:mock_command(rebar3_hex_user, Command, Repo, State),
+    RepoConfig = [{repos,[Repo]}],
+    {ok, BadcommandState} = test_utils:mock_command(rebar3_hex_user, Command, RepoConfig, State),
 
     ?assertThrow({error,{rebar3_hex_user,bad_command}}, rebar3_hex_user:do(BadcommandState)).
 

--- a/test/support/test_utils.erl
+++ b/test/support/test_utils.erl
@@ -30,7 +30,7 @@ mock_app(AppName, DataDir, Repo) ->
 mock_command(ProviderName, Command, Repo, State0) ->
     State1 = rebar_state:add_resource(State0, {pkg, rebar_pkg_resource}),
     State2 = rebar_state:create_resources([{pkg, rebar_pkg_resource}], State1),
-    State3 = rebar_state:set(State2, hex, {repos,[Repo]}),
+    State3 = rebar_state:set(State2, hex, [{repos,[Repo]}]),
     State4 = rebar_state:command_args(State3, Command),
     {ok, State5} = ProviderName:init(State4),
 

--- a/test/support/test_utils.erl
+++ b/test/support/test_utils.erl
@@ -27,10 +27,10 @@ mock_app(AppName, DataDir, Repo) ->
     State = rebar_state:project_apps(rebar_state(Repo), [App]),
     {ok, App, State}.
 
-mock_command(ProviderName, Command, Repo, State0) ->
+mock_command(ProviderName, Command, RepoConfig, State0) ->
     State1 = rebar_state:add_resource(State0, {pkg, rebar_pkg_resource}),
     State2 = rebar_state:create_resources([{pkg, rebar_pkg_resource}], State1),
-    State3 = rebar_state:set(State2, hex, [{repos,[Repo]}]),
+    State3 = rebar_state:set(State2, hex, RepoConfig),
     State4 = rebar_state:command_args(State3, Command),
     {ok, State5} = ProviderName:init(State4),
 


### PR DESCRIPTION
This provides the minimal amount of support to fulfil #57 and support #181 . It can be extended to support edoc opts, maybe that should be done here in this PR, but I figured just go with the MVP. Other cases will arise and we can add support for them as needed (i.e., other providers, options, shell commands, etc.). 