### PR TITLE
Add (CHANGELOG|changelog)* to DEFAULT_FILES

### DIFF
--- a/src/rebar3_hex.hrl
+++ b/src/rebar3_hex.hrl
@@ -1,5 +1,6 @@
 -define(DEFAULT_FILES, ["src", "c_src", "include", "rebar.config.script"
                        ,"priv", "rebar.config", "rebar.lock"
+                       ,"CHANGELOG*", "changelog*"
                        ,"README*", "readme*"
                        ,"LICENSE*", "license*"
                        ,"NOTICE"]).


### PR DESCRIPTION
 - update DEFAULT_FILES macro to include CHANGELOG* or changelog* to
 mirror what mix hex does.