### PR TITLE
Use crypto_one_time_aead on OTP 23 and onwards

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,6 +2,7 @@
 
 {erl_opts, [
     debug_info,
+    {platform_define, "^23", 'POST_OTP_22'},
     {platform_define, "^20", 'POST_OTP_19'},
     {platform_define, "^19", 'POST_OTP_18'},
     {platform_define, "^[2-9]", 'POST_OTP_18'}

--- a/src/rebar3_hex_user.erl
+++ b/src/rebar3_hex_user.erl
@@ -241,14 +241,14 @@ generate_all_keys(Username, Password, LocalPassword, Repo, State) ->
     end.
 
 -ifdef(POST_OTP_22).
--spec encrypt_write_key(binary(), binary(), binary()) -> {binary(), binary(), binary(), {binary(), binary()}}.
+-spec encrypt_write_key(binary(), binary(), binary()) -> {binary(), {binary(), binary()}}.
 encrypt_write_key(Username, LocalPassword, WriteKey) ->
     AAD = Username,
     IV = crypto:strong_rand_bytes(16),
     Key =  pad(LocalPassword),
     {IV, crypto:crypto_one_time_aead(cipher(Key), Key, IV, WriteKey, AAD, true)}.
 -else.
--spec encrypt_write_key(binary(), binary(), binary()) -> {binary(), binary(), binary(), {binary(), binary()}}.
+-spec encrypt_write_key(binary(), binary(), binary()) -> {binary(), {binary(), binary()}}.
 encrypt_write_key(Username, LocalPassword, WriteKey) ->
     AAD = Username,
     IV = crypto:strong_rand_bytes(16),
@@ -281,9 +281,11 @@ decrypt_write_key(Username, LocalPassword, {IV, {CipherText, CipherTag}}) ->
     end.
 -endif.
 
+-ifdef(POST_OTP_22).
 cipher(Key) when size(Key) == 16  -> aes_128_gcm;
 cipher(Key) when size(Key) == 24  -> aes_192_gcm;
 cipher(Key) when size(Key) == 32  -> aes_256_gcm.
+-endif.
 
 generate_key(RepoConfig, KeyName, Permissions) ->
     case hex_api_key:add(RepoConfig, KeyName, Permissions) of

--- a/src/rebar3_hex_user.erl
+++ b/src/rebar3_hex_user.erl
@@ -282,9 +282,9 @@ decrypt_write_key(Username, LocalPassword, {IV, {CipherText, CipherTag}}) ->
 -endif.
 
 -ifdef(POST_OTP_22).
-cipher(Key) when size(Key) == 16  -> aes_128_gcm;
-cipher(Key) when size(Key) == 24  -> aes_192_gcm;
-cipher(Key) when size(Key) == 32  -> aes_256_gcm.
+cipher(Key) when byte_size(Key) == 16  -> aes_128_gcm;
+cipher(Key) when byte_size(Key) == 24  -> aes_192_gcm;
+cipher(Key) when byte_size(Key) == 32  -> aes_256_gcm.
 -endif.
 
 generate_key(RepoConfig, KeyName, Permissions) ->

--- a/src/rebar3_hex_user.erl
+++ b/src/rebar3_hex_user.erl
@@ -240,18 +240,38 @@ generate_all_keys(Username, Password, LocalPassword, Repo, State) ->
             Error
     end.
 
+-ifdef(POST_OTP_22).
+-spec encrypt_write_key(binary(), binary(), binary()) -> {binary(), binary(), binary(), {binary(), binary()}}.
+encrypt_write_key(Username, LocalPassword, WriteKey) ->
+    AAD = Username,
+    IV = crypto:strong_rand_bytes(16),
+    Key =  pad(LocalPassword),
+    {IV, crypto:crypto_one_time_aead(cipher(Key), Key, IV, WriteKey, AAD, true)}.
+-else.
+-spec encrypt_write_key(binary(), binary(), binary()) -> {binary(), binary(), binary(), {binary(), binary()}}.
 encrypt_write_key(Username, LocalPassword, WriteKey) ->
     AAD = Username,
     IV = crypto:strong_rand_bytes(16),
     {IV, crypto:block_encrypt(aes_gcm, pad(LocalPassword), IV, {AAD, WriteKey})}.
+-endif.
 
-
+-spec decrypt_write_key(binary(), {binary(), {binary(), binary()}} | undefined) -> binary().
 decrypt_write_key(_Username, undefined) ->
     {error, no_write_key};
 decrypt_write_key(Username, {IV, {CipherText, CipherTag}}) ->
     LocalPassword = rebar3_hex_io:get_password(<<"Local Password: ">>),
     decrypt_write_key(Username, LocalPassword, {IV, {CipherText, CipherTag}}).
 
+-ifdef(POST_OTP_22).
+decrypt_write_key(Username, LocalPassword, {IV, {CipherText, CipherTag}}) ->
+    Key = pad(LocalPassword),
+    case crypto:crypto_one_time_aead(cipher(Key), Key, IV, CipherText, Username, CipherTag, false) of
+        error ->
+            throw(?PRV_ERROR(bad_local_password));
+        Result ->
+            Result
+    end.
+-else.
 decrypt_write_key(Username, LocalPassword, {IV, {CipherText, CipherTag}}) ->
     case crypto:block_decrypt(aes_gcm, pad(LocalPassword), IV, {Username, CipherText, CipherTag}) of
         error ->
@@ -259,6 +279,11 @@ decrypt_write_key(Username, LocalPassword, {IV, {CipherText, CipherTag}}) ->
         Result ->
             Result
     end.
+-endif.
+
+cipher(Key) when size(Key) == 16  -> aes_128_gcm;
+cipher(Key) when size(Key) == 24  -> aes_192_gcm;
+cipher(Key) when size(Key) == 32  -> aes_256_gcm.
 
 generate_key(RepoConfig, KeyName, Permissions) ->
     case hex_api_key:add(RepoConfig, KeyName, Permissions) of


### PR DESCRIPTION
 - updated rebar3_hex_user to use crypto:crypto_one_time_aead/6 and
 crypto:crypto_one_time_aead/7 if OTP is equal to or greater than 23

 - added private function cipher/1 to determine the correct cipher to
 use with crypto:crypto_one_time_aead/6 and crypto:crypto_one_time_aead/7

 - standardize on upper case platform_define(s) in rebar.config