### PR TITLE
Fix crypto-related compilation issues under OTP 24

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 
 {erl_opts, [
     debug_info,
-    {platform_define, "^23", 'POST_OTP_22'},
+    {platform_define, "^2[3-9]", 'POST_OTP_22'},
     {platform_define, "^20", 'POST_OTP_19'},
     {platform_define, "^19", 'POST_OTP_18'},
     {platform_define, "^[2-9]", 'POST_OTP_18'}


### PR DESCRIPTION
This seems like a half-baked solution to me, though, but it'll hold for a couple of years, I guess :)

I thought about using `OTP_RELEASE` but that would involve duplicating pre-OTP 22 code, specifically for OTP 21.

Let me know. Otherwise, if you're OK with it, I'd appreciate a release since many lib.s depend on the latest tag.