### PR TITLE
Fix owner list package

### DIFF
--- a/src/rebar3_hex_owner.erl
+++ b/src/rebar3_hex_owner.erl
@@ -168,7 +168,7 @@ remove(HexConfig, Package, UsernameOrEmail, State) ->
 list(HexConfig, Package, State) ->
     case hex_api_package_owner:list(HexConfig, Package) of
         {ok, {200, _Headers, List}} ->
-            Owners = [binary_to_list(maps:get(<<"email">>, Owner, <<"">>)) || Owner <- List],
+            Owners = [owner_email(Owner) || Owner <- List],
             OwnersString = rebar_string:join(Owners, "\n"),
             rebar3_hex_io:say("~s", [OwnersString]),
             {ok, State};
@@ -176,6 +176,12 @@ list(HexConfig, Package, State) ->
             ?PRV_ERROR({status, Status, Package});
         {error, Reason} ->
             ?PRV_ERROR({error, Package, Reason})
+    end.
+
+owner_email(Owner) ->
+    case maps:get(<<"email">>, Owner, <<"">>) of
+        Email when is_binary(Email) -> binary_to_list(Email);
+        _ -> "unspecified"
     end.
 
 verb_to_gerund(add) -> "adding";

--- a/src/rebar3_hex_owner.erl
+++ b/src/rebar3_hex_owner.erl
@@ -64,8 +64,7 @@ handle_command(State, Repo) ->
             {ok, State};
         {"list", Package} ->
             {ok, Config} = rebar3_hex_config:hex_config_read(Repo),
-            {ok, State} = list(Config, Package, State),
-            {ok, State};
+            list(Config, Package, State);
         _Command ->
             ?PRV_ERROR(bad_command)
     end.

--- a/test/rebar3_hex_integration_SUITE.erl
+++ b/test/rebar3_hex_integration_SUITE.erl
@@ -691,7 +691,7 @@ setup_mocks_for(owner, #{password := Password}) ->
                   case {Templ, Args} of
                       {_, [_UserOrOrg, _Package]} -> %% add/remove
                           ok;
-                      {"~s",[[]]} ->  %% list
+                      {"~s",["unspecified (unspecified)"]} ->  %% list
                           ok
                   end
           end,


### PR DESCRIPTION
There's two fixes to this:
1. if a package doesn't exist we don't crash, but instead output `Error listing owners of package PACKAGE: Entity not found (404)` (where `PACKAGE` is the queried one),
2. if a package's owner doesn't have his email listed we don't crash[1]

---
[1] regarding this I don't know if 1. this is an Hex issue, that shouldn't return an empty e-mail field, an `httpc` issue (because the field is defined as `nil`) or a `rebar3_hex` issue, in which case the fix might be acceptable.