### PR TITLE
Gracefully handle undefined task in rebar3_hex:task_args/1

### DIFF
--- a/src/rebar3_hex.erl
+++ b/src/rebar3_hex.erl
@@ -43,8 +43,13 @@ get_required(Key, Args) ->
     end.
 
 task_args(State) ->
-    {[{task, Task} | Args], _} = rebar_state:command_parsed_args(State),
-    {Task, Args}.
+    {Opts, _Args} = rebar_state:command_parsed_args(State),
+    case proplists:get_value(task, Opts, undefined) of
+        undefined ->
+            {undefined, Opts};
+        Task ->
+            {Task, proplists:delete(task, Opts)}
+    end.
 
 repo_opt() ->
   {repo, $r, "repo", string, "Repository to use for this command."}.

--- a/test/rebar3_hex_SUITE.erl
+++ b/test/rebar3_hex_SUITE.erl
@@ -8,17 +8,20 @@ all() ->
     [task_args_test, gather_opts_test, init_test, help_test, repo_opt].
 
 
-gather_opts_test(_Config) -> 
+gather_opts_test(_Config) ->
     State = rebar_state:new(),
     CmdArgs = {[{foo,"bar"}, {count, 42}, {other, eh}], []},
     State1 = rebar_state:command_parsed_args(State, CmdArgs),
     ?assertMatch(#{count := 42, foo := "bar"}, rebar3_hex:gather_opts([count, foo], State1)).
 
-task_args_test(_Config) -> 
+task_args_test(_Config) ->
     State = rebar_state:new(),
-    CmdArgs = {[{task, thing} | {[{foo,"bar"}, {count, 42}], []}], []},
+    CmdArgs = {[{task, thing}, {foo,"bar"}, {count, 42}], []},
     State1 = rebar_state:command_parsed_args(State, CmdArgs),
-    ?assertMatch({thing,{[{foo,"bar"},{count,42}],[]}}, rebar3_hex:task_args(State1)).
+    ?assertMatch({thing,[{foo,"bar"},{count,42}]}, rebar3_hex:task_args(State1)),
+    CmdArgs2 = {[{foo,"bar"}, {count, 42}], []},
+    State2 = rebar_state:command_parsed_args(State, CmdArgs2),
+    ?assertMatch({undefined,[{foo,"bar"},{count,42}]}, rebar3_hex:task_args(State2)).
 
 repo_opt(_Config) ->
     ?assertEqual({repo,114,"repo",string,
@@ -29,12 +32,12 @@ init_test(_Config) ->
     ?assertEqual(state_t, element(1, State)).
 
 %% Smoke test to ensure we don't crash
-help_test(_Config) -> 
+help_test(_Config) ->
     %% Silent output during our tests
     ok =  meck:new(io_lib, [unstick, passthrough]),
     meck:expect(io_lib, format, 2, fun(_,_) -> "" end),
     Checks = [
-                {rebar3_hex_publish, publish}, 
+                {rebar3_hex_publish, publish},
                 {rebar3_hex_revert, revert},
                 {rebar3_hex_cut, cut},
                 {rebar3_hex_key, key},
@@ -48,7 +51,7 @@ help_test(_Config) ->
     meck:unload(io_lib),
     ok.
 
-get_help({Mod, Task}) -> 
+get_help({Mod, Task}) ->
     State = rebar_state:new(),
     {ok, State1} = Mod:init(State),
     Providers = rebar_state:providers(State1),


### PR DESCRIPTION
 - Closes #201  
 - in case there is no task key defined, return `{undefined, Opts}`
 - use proplists to attempt to get the task vs matching