### PR TITLE
Add support for a dry run option on docs task

### DIFF
--- a/src/rebar3_hex_docs.erl
+++ b/src/rebar3_hex_docs.erl
@@ -123,7 +123,7 @@ do_publish(App, State, Repo) ->
     {Args, _} = rebar_state:command_parsed_args(State),
     case proplists:get_bool(dry_run, Args) of
         true ->
-            rebar_api:info("Dry run mode enabled, will not publish docs.", []),
+            rebar_api:info("--dry-run enabled : will not publish docs.", []),
             {ok, State};
         false ->
             case rebar3_hex_client:publish_docs(Config, rebar_utils:to_binary(PkgName), rebar_utils:to_binary(Vsn), Tar) of

--- a/src/rebar3_hex_docs.erl
+++ b/src/rebar3_hex_docs.erl
@@ -29,6 +29,7 @@ init(State) ->
                                 {short_desc, "Publish documentation for the current project and version"},
                                 {desc, ""},
                                 {opts, [{revert, undefined, "revert", string, "Revert given version."},
+                                        {dry_run, undefined, "dry-run", {boolean, false}, help(dry_run)},
                                         rebar3_hex:repo_opt()]},
                                 {profiles, [docs]}]),
     State1 = rebar_state:add_provider(State, Provider),
@@ -74,6 +75,9 @@ format_error(Reason) ->
 %% Internal Functions
 %% ===================================================================
 
+help(dry_run) ->
+    "Generates docs (if configured) but does not publish the docs. Useful for inspecting docs before publishing.".
+
 publish_apps(Apps, State) ->
     lists:foldl(fun(App, {ok, StateAcc}) ->
                         case handle_command(App, StateAcc) of
@@ -116,12 +120,19 @@ do_publish(App, State, Repo) ->
 
     {ok, Config} = rebar3_hex_config:hex_config_write(Repo),
 
-    case rebar3_hex_client:publish_docs(Config, rebar_utils:to_binary(PkgName), rebar_utils:to_binary(Vsn), Tar) of
-        {ok, _} ->
-            rebar_api:info("Published docs for ~ts ~ts", [PkgName, Vsn]),
+    {Args, _} = rebar_state:command_parsed_args(State),
+    case proplists:get_bool(dry_run, Args) of
+        true ->
+            rebar_api:info("Dry run mode enabled, will not publish docs.", []),
             {ok, State};
-        Reason ->
-            ?PRV_ERROR({publish, Reason})
+        false ->
+            case rebar3_hex_client:publish_docs(Config, rebar_utils:to_binary(PkgName), rebar_utils:to_binary(Vsn), Tar) of
+            {ok, _} ->
+                rebar_api:info("Published docs for ~ts ~ts", [PkgName, Vsn]),
+                {ok, State};
+            Reason ->
+                ?PRV_ERROR({publish, Reason})
+            end
     end.
 
 vsn_string(<<Vsn/binary>>) ->

--- a/test/rebar3_hex_integration_SUITE.erl
+++ b/test/rebar3_hex_integration_SUITE.erl
@@ -15,6 +15,7 @@ all() ->
     , docs_test
     , docs_auth_error_test
     , docs_dir_error_test
+    , docs_dry_run_test
     , docs_invalid_repo_test
     , docs_no_write_key_test
     , docs_revert_test
@@ -131,6 +132,15 @@ docs_dir_error_test(Config) ->
     RepoConfig = [{repos,[Repo]}],
     {ok, NewState} = test_utils:mock_command(rebar3_hex_docs, Command, RepoConfig, State),
     ?assertThrow(rebar_abort, rebar3_hex_docs:do(NewState)).
+
+docs_dry_run_test(Config) ->
+    P = #{app => "valid", mocks => [docs]},
+    {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
+    Command = ["--dry-run"],
+    RepoConfig =  [{repos,[Repo]}],
+    {ok, DocState} = test_utils:mock_command(rebar3_hex_docs, Command, RepoConfig, State),
+    {ok, NewState} = rebar_prv_edoc:do(DocState),
+    ?assertMatch({ok, NewState}, rebar3_hex_docs:do(NewState)).
 
 docs_revert_test(Config) ->
     P = #{app => "valid", mocks => [docs]},


### PR DESCRIPTION
 - Added dry-run long option on docs task. When enabled will maybe generate docs if configured, but regardless will not publish docs. This is useful for inspecting docs before publishing.