### PR TITLE
Validate version argument on revert task

### DIFF
--- a/src/rebar3_hex_revert.erl
+++ b/src/rebar3_hex_revert.erl
@@ -54,11 +54,17 @@ handle_command(State, Repo) ->
                 undefined ->
                     ?PRV_ERROR(version_required);
                 Version ->
-                    case revert(PkgName, rebar_utils:to_binary(Version), Repo, State) of
-                        ok ->
-                            {ok, State};
-                        Error ->
-                            Error
+                    case verl:parse(rebar_utils:to_binary(Version)) of
+                        {ok, _} ->
+                            case revert(PkgName, rebar_utils:to_binary(Version), Repo, State) of
+                                ok ->
+                                    {ok, State};
+                                Error ->
+                                    Error
+                            end;
+                        _ ->
+                            Msg = "The version argument provided \"~s\" is not a valid semantic version.",
+                            rebar_api:abort(Msg, [Version])
                     end
             end
     end.

--- a/test/rebar3_hex_integration_SUITE.erl
+++ b/test/rebar3_hex_integration_SUITE.erl
@@ -56,7 +56,8 @@ all() ->
     , owner_add_test
     , owner_transfer_test
     , owner_list_test
-    , owner_remove_test].
+    , owner_remove_test
+    , revert_invalid_ver_test].
 
 init_per_suite(Config) ->
     meck:new([hex_api_user, rebar3_hex_config, rebar3_hex_io], [passthrough, no_link, unstick]),
@@ -627,6 +628,13 @@ bad_command_test(Config) ->
 
     ?assertThrow({error,{rebar3_hex_user,bad_command}}, rebar3_hex_user:do(BadcommandState)).
 
+revert_invalid_ver_test(Config) ->
+    P = #{app => "valid", mocks => [publish_revert], version => "eh?"},
+    {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
+    RepoConfig = [{repos,[Repo]}],
+    {ok, RevState} = test_utils:mock_command(rebar3_hex_revert, ["valid", "eh?"], RepoConfig, State),
+
+     ?assertThrow(rebar_abort, rebar3_hex_revert:do(RevState)).
 %%%%%%%%%%%%%%%%%%
 %%%  Helpers   %%%
 %%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
 - previously if an invalid semantic version was given, we'd simply pass
 this on to hex and hex would return a 400, which is not helpful to
 users
 - closes #214