### PR TITLE
Switch to setup-beam github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp: ['20.3.8.9', '21.3.8.9', '22.3.4.9', '23.3.1']
+        otp: ['20', '21', '22', '23']
         rebar3: ['3.14.1', '3.14.2', '3.14.3']
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         otp: ['20', '21', '22', '23']
-        rebar3: ['3.14.1', '3.14.2', '3.14.3', '3.14.3']
+        rebar3: ['3.14.1', '3.14.2', '3.14.3', '3.14.4']
     steps:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1.7.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,23 +1,46 @@
 ---
-name: build
+name: test
 on:
   push:
     branches:
       - master
   pull_request:
-    branches:
-      - master
+    types: [opened, synchronize]
+
 jobs:
-  ci:
-    name: >
-      Run checks and tests over ${{matrix.otp_vsn}} and ${{matrix.os}}
-    runs-on: ${{matrix.os}}
-    container:
-      image: erlang:${{matrix.otp_vsn}}
+  test:
+    name: Erlang/OTP ${{matrix.otp}} / rebar3 ${{matrix.rebar3}}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp_vsn: [19.3, 20.3, 21.3, 22.3, 23.2]
-        os: [ubuntu-latest]
+        otp: ['20.3.8.9', '21.3.8.9', '22.3.4.9', '23.3.1']
+        rebar3: ['3.14.1', '3.14.2', '3.14.3']
+    steps:
+      - uses: actions/checkout@v2
+      - uses: erlef/setup-beam@v1.7.0
+        with:
+          otp-version: ${{matrix.otp}}
+          rebar3-version: ${{matrix.rebar3}}
+      - name: Cross reference analysis
+        run: rebar3 as test xref
+      - name: Static analysis
+        run: rebar3 dialyzer
+      - name: Common Tests
+        run: rebar3 ct
+      - name: Code coverage
+        run: rebar3 as test do cover,covertool generate
+      - name: Upload coverage report
+        uses: codecov/codecov-action@v1
+        with:
+          files: _build/test/covertool/verl.covertool.xml
+          name: ${{matrix.otp_vsn}}
+
+  test-19:
+    name: >
+      Run checks and tests over Erlang/OTP 19.3
+    runs-on: ubuntu-latest
+    container:
+      image: erlang:19.3
     steps:
       - name: Git checkout
         uses: actions/checkout@v2
@@ -31,4 +54,4 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           files: _build/test/covertool/rebar3_hex.covertool.xml
-          name: ${{matrix.otp_vsn}}
+          name: 19.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,6 @@ jobs:
         with:
           otp-version: ${{matrix.otp}}
           rebar3-version: ${{matrix.rebar3}}
-      - name: Cross reference analysis
-        run: rebar3 as test xref
       - name: Static analysis
         run: rebar3 dialyzer
       - name: Common Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         otp: ['20', '21', '22', '23']
-        rebar3: ['3.14.1', '3.14.2', '3.14.3']
+        rebar3: ['3.14.1', '3.14.2', '3.14.3', '3.14.3']
     steps:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1.7.0


### PR DESCRIPTION
 - changes ci.yml to use setup-beam for all tests, except 19 which is still an ongoing issue with setup-beam