### PR TITLE
Add custom hex httpc adapter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp: ['20', '21', '22', '23', '24']
-        rebar3: ['3.14.2', '3.14.3', '3.14.4', '3.15.0', '3.15.1']
+        otp: ['22', '23', '24']
+        rebar3: ['3.16.1']
     steps:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1
@@ -32,24 +32,3 @@ jobs:
         with:
           files: _build/test/covertool/verl.covertool.xml
           name: ${{matrix.otp_vsn}}
-
-  test-19:
-    name: >
-      Run checks and tests over Erlang/OTP 19.3
-    runs-on: ubuntu-latest
-    container:
-      image: erlang:19.3
-    steps:
-      - name: Git checkout
-        uses: actions/checkout@v2
-      - name: Static analysis
-        run: rebar3 dialyzer
-      - name: Common Tests
-        run: rebar3 ct
-      - name: Code coverage
-        run: rebar3 as test do cover,covertool generate
-      - name: Upload coverage report
-        uses: codecov/codecov-action@v1
-        with:
-          files: _build/test/covertool/rebar3_hex.covertool.xml
-          name: 19.3

--- a/src/rebar3_hex.app.src
+++ b/src/rebar3_hex.app.src
@@ -1,7 +1,7 @@
 {application,rebar3_hex,
  [{description,"Hex.pm plugin for rebar3"},
   {vsn,"git"},
-  {applications, [kernel,stdlib]},
+  {applications, [kernel,stdlib,hex_core]},
   {maintainers, ["Tristan Sloughter"]},
   {licenses, ["MIT"]},
   {links, [{"Github", "https://github.com/tsloughter/rebar3_hex"}]}]}.

--- a/src/rebar3_hex_config.erl
+++ b/src/rebar3_hex_config.erl
@@ -126,7 +126,7 @@ maybe_env_val(K, {_, {Type, Default}}) ->
     end.
 
 set_http_adapter(Repo) ->
-    Repo#{http_adapter => {hex_http_httpc, #{profile => rebar}}}.
+    Repo#{http_adapter => {rebar3_hex_httpc_adapter, #{profile => rebar}}}.
 
 to_bool("0") -> false;
 to_bool("false") -> false;

--- a/src/rebar3_hex_docs.erl
+++ b/src/rebar3_hex_docs.erl
@@ -146,7 +146,7 @@ do_revert(App, State, Repo, Vsn) ->
     Name = rebar_utils:to_list(rebar_app_info:name(App)),
     PkgName = rebar_utils:to_list(proplists:get_value(pkg_name, AppDetails, Name)),
     case rebar3_hex_client:delete_docs(Config, rebar_utils:to_binary(PkgName), rebar_utils:to_binary(Vsn)) of
-        {modified, _Body} ->
+        {ok, _} ->
             rebar_api:info("Successfully deleted docs for ~ts ~ts", [Name, Vsn]),
             {ok, State};
         Reason ->

--- a/src/rebar3_hex_httpc_adapter.erl
+++ b/src/rebar3_hex_httpc_adapter.erl
@@ -1,0 +1,41 @@
+%% Derived from rebar3_httpc_adapter, which was derived from hex_core v0.7.1 for extra flexibility.
+
+-module(rebar3_hex_httpc_adapter).
+-behaviour(hex_http).
+-export([request/5]).
+
+%%====================================================================
+%% API functions
+%%====================================================================
+
+request(Method, URI, ReqHeaders, Body, AdapterConfig) ->
+    Profile = maps:get(profile, AdapterConfig, default),
+    Request = build_request(URI, ReqHeaders, Body),
+    SSLOpts = [{ssl, rebar_utils:ssl_opts(URI)}],
+    case httpc:request(Method, Request, SSLOpts, [{body_format, binary}], Profile) of
+        {ok, {{_, StatusCode, _}, RespHeaders, RespBody}} ->
+            RespHeaders2 = load_headers(RespHeaders),
+            {ok, {StatusCode, RespHeaders2, RespBody}};
+        {error, Reason} -> {error, Reason}
+    end.
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+build_request(URI, ReqHeaders, Body) ->
+    build_request2(binary_to_list(URI), dump_headers(ReqHeaders), Body).
+
+build_request2(URI, ReqHeaders, undefined) ->
+    {URI, ReqHeaders};
+build_request2(URI, ReqHeaders, {ContentType, Body}) ->
+    {URI, ReqHeaders, ContentType, Body}.
+
+dump_headers(Map) ->
+    maps:fold(fun(K, V, Acc) ->
+        [{binary_to_list(K), binary_to_list(V)} | Acc] end, [], Map).
+
+load_headers(List) ->
+    lists:foldl(fun({K, V}, Acc) ->
+        maps:put(list_to_binary(K), list_to_binary(V), Acc) end, #{}, List).
+

--- a/src/rebar3_hex_user.erl
+++ b/src/rebar3_hex_user.erl
@@ -63,7 +63,7 @@ do(State) ->
     end.
 
 
-
+-dialyzer({[no_return, no_match], handle/2}).
 handle(whoami, State) ->
     {ok, Parents} = rebar3_hex_config:parent_repos(State),
     lists:foreach(fun(R) -> case whoami(R, State) of
@@ -110,6 +110,7 @@ hex_register(Repo, State) ->
             end
     end.
 
+-dialyzer({no_fail_call, whoami/2}).
 whoami(#{name := Name} = Repo, State) ->
     case maps:get(read_key, Repo, undefined) of
         undefined ->
@@ -127,6 +128,7 @@ whoami(#{name := Name} = Repo, State) ->
             end
     end.
 
+ -dialyzer({no_return, auth/2}).
 auth(Repo, State) ->
     Username = list_to_binary(rebar3_hex_io:ask("Username:", string, "")),
     Password = get_account_password(),
@@ -175,6 +177,7 @@ get_account_password() ->
 get_account_password(confirm) ->
     rebar3_hex_io:get_password(<<"Account Password (confirm): ">>).
 
+-dialyzer({no_fail_call, create_user/5}).
 create_user(Username, Email, Password, Repo, State) ->
     case hex_api_user:create(Repo, Username, Password, Email) of
         {ok, {201, _Headers, _Body}} ->
@@ -200,6 +203,7 @@ pad(Binary) ->
             <<Binary/binary, 0:((32 - Size) * 8)>>
     end.
 
+-dialyzer({no_return, generate_all_keys/5}).
 generate_all_keys(Username, Password, LocalPassword, Repo, State) ->
     rebar3_hex_io:say("Generating all keys..."),
 

--- a/test/support/test_utils.erl
+++ b/test/support/test_utils.erl
@@ -23,9 +23,10 @@ mock_app(AppName, DataDir) ->
 
 mock_app(AppName, DataDir, Repo) ->
     Src = filename:join([DataDir, "test_apps/" ++ AppName]),
-    {ok, App} = rebar_app_info:discover(Src),
-    State = rebar_state:project_apps(rebar_state(Repo), [App]),
-    {ok, App, State}.
+    State = rebar_state:new(), 
+    {ok, App} = rebar_app_info:discover(Src, State),
+    State1 = rebar_state:project_apps(rebar_state(Repo), [App]),
+    {ok, App, State1}.
 
 mock_command(ProviderName, Command, RepoConfig, State0) ->
     State1 = rebar_state:add_resource(State0, {pkg, rebar_pkg_resource}),


### PR DESCRIPTION
 Per https://ferd.ca/you-ve-got-to-upgrade-rebar3.html we must provide our own http adapter so we can ensure ssl opts are set. Note that we can provide the default hex core httpc adapter ssl options, however having a custom adapter will provide us greater flexibility long term. This especially true in the case of custom repositories for which the edge cases around ssl are unknown.

- Added rebar3_hex_httpc_adapter copied from rebar3.
- Changed rebar3_hex_config to use rebar3_hex_httpc_adapter instead of the default hex_core http adapter
- Changed test/support/test_utils.erl to work with rebar3 version 3.16
- Changed .github/workflows/ci.yml to only test against 3.16.1
- Fixed a bug in rebar3_hex_docs where our call to rebar3_hex_client:delete_docs/3 had wrong expectations
- Suppressed some dialyzer warnings that should be fixed up in a subsequent PR