### PR TITLE
Revert "Add V7 publish options"

### DIFF
--- a/src/rebar3_hex.erl
+++ b/src/rebar3_hex.erl
@@ -1,18 +1,12 @@
 -module(rebar3_hex).
 
 -export([ init/1
-        , get_args/1
         , gather_opts/2
         , get_required/2
         , task_args/1
-        , task_state/1
         , repo_opt/0
         , help_opt/0
         ]).
-
--type task() :: #{args := map(), repo := map(), state := rebar_state:t()}.
-
--export_type([task/0]).
 
 init(State) ->
     lists:foldl(fun provider_init/2, {ok, State}, [rebar3_hex_user,
@@ -56,47 +50,6 @@ task_args(State) ->
         Task ->
             {Task, proplists:delete(task, Opts)}
     end.
-
--spec task_state(rebar_state:t()) -> {ok, task()} | {error, term()}.
-task_state(State) ->
-     case rebar3_hex_config:repo(State) of
-         {ok, Repo} -> 
-             Opts = get_args(State),
-             {ok, #{args => Opts, repo => Repo, state => State}};
-         Err -> 
-            Err
-     end.
-
--spec get_args(rebar_state:t()) -> map().
-get_args(State) -> 
-    {Opts, Args} = rebar_state:command_parsed_args(State),
-    Opts1 = lists:foldl(fun (Arg, Acc) ->
-                                case is_atom(Arg) of
-                                    true ->
-                                        [{Arg, true} | Acc];
-                                    _ ->
-                                        case Arg of
-                                            {task, Task} ->
-                                                [{task, list_to_atom(Task)} | Acc];
-                                             _ -> 
-                                              [Arg | Acc]
-                                        end
-                                end
-                        end,
-                        [],
-                        Opts),
-    
-    Opts2 = lists:foldl(fun (Arg, Acc) ->
-                                case is_atom(Arg) of
-                                    true ->
-                                        [{Arg, true} | Acc];
-                                    _ ->
-                                     [{list_to_atom(Arg), true} | Acc]
-                                end
-                        end,
-                        Opts1,
-                        Args),
-    maps:from_list(Opts2).
 
 repo_opt() ->
   {repo, $r, "repo", string, "Repository to use for this command."}.

--- a/src/rebar3_hex_publish.erl
+++ b/src/rebar3_hex_publish.erl
@@ -56,34 +56,38 @@ init(State) ->
                                  {opts, [rebar3_hex:repo_opt(),
                                          {yes, $y, "yes", {boolean, false}, help(yes)},
                                          {replace, undefined, "replace", {boolean, false}, help(replace)},
-                                         {revert, undefined, "revert", string, help(revert)}]}]),
+                                         {package, $p, "package", string, help(package)},
+                                         {revert, undefined, "revert", string, help(revert)},
+                                         {without_docs, undefined, "without-docs", {boolean, false}, help(without_docs)}]}]),
     State1 = rebar_state:add_provider(State, Provider),
     {ok, State1}.
 
--spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, term()}.
+-spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
 do(State) ->
-    case rebar3_hex:task_state(State) of
-        {ok, Task} -> 
-            handle_task(Task);
-        {error, Reason} -> 
+    case rebar3_hex_config:repo(State) of
+        {ok, Repo} ->
+            OptMap = rebar3_hex:gather_opts([revert, package], State),
+            handle_command(OptMap, State, Repo);
+        {error, Reason} ->
             ?PRV_ERROR(Reason)
-    end.
+        end.
 
-handle_task(#{args := #{revert := undefined}}) ->
-    {error, "--revert requires an app version"};
-
-handle_task(#{args := #{revert := Vsn}, repo := Repo, state := State}) ->
-    App = rebar_state:current_app(State),
-    Name = rebar_app_info:name(App),
-    ok = rebar3_hex_revert:revert(binarify(Name), binarify(Vsn), Repo, State),
+handle_command(#{revert := Vsn, package := Pkg}, State, Repo) ->
+    ok = rebar3_hex_revert:revert(binarify(Pkg), binarify(Vsn), Repo, State),
     {ok, State};
 
-handle_task(#{repo := Repo, state := State}) ->
+handle_command(#{revert := _Vsn}, _State, _Repo) ->
+    {error, "--revert requires a package name"};
+
+handle_command(_Args, State, Repo) ->
         case maps:get(write_key, Repo, maps:get(api_key, Repo, undefined)) of
             undefined ->
                 ?PRV_ERROR(no_write_key);
             _ ->
-                publish(rebar_state:current_app(State), Repo, State)
+                Apps = rebar3_hex_io:select_apps(rebar_state:project_apps(State)),
+                lists:foldl(fun(App, {ok, StateAcc}) ->
+                                    publish(App, Repo, StateAcc)
+                            end, {ok, State}, Apps)
         end.
 
 -spec format_error(any()) -> iolist().
@@ -257,27 +261,19 @@ publish_package_and_docs(Name, Version, Metadata, PackageFiles, HexConfig, App, 
     HexOpts = hex_opts(Args),
     case rebar3_hex_config:hex_config_write(HexConfig) of
         {ok, HexConfig1} ->
-            case proplists:get_value(task, Args, undefined) of
-                "package" -> 
-                    rebar_api:info("package argument given, will not publish docs", []),
-                    case create_and_publish(HexOpts, Metadata, PackageFiles, HexConfig1) of
-                        ok -> 
-                          rebar_api:info("Published ~s ~s", [Name, Version]),
-                          {ok, State};
-                        Error ->
-                          Error
+            case create_and_publish(HexOpts, Metadata, PackageFiles, HexConfig1) of
+                ok ->
+                    rebar_api:info("Published ~s ~s", [Name, Version]),
+                    case proplists:get_bool(without_docs, Args) of
+                        true ->
+                            rebar_api:info("--without-docs is enabled : will not publish docs", []),
+                            {ok, State};
+                        false ->
+                            rebar3_hex_docs:publish(App, State, HexConfig1),
+                            {ok, State}
                     end;
-                "docs" -> 
-                    rebar_api:info("docs argument given, will not publish package", []),
-                    rebar3_hex_docs:publish(App, State, HexConfig1);
-                _ -> 
-                    case create_and_publish(HexOpts, Metadata, PackageFiles, HexConfig1) of
-                        ok -> 
-                          rebar_api:info("Published ~s ~s", [Name, Version]),
-                          rebar3_hex_docs:publish(App, State, HexConfig1);
-                        Error ->
-                          Error
-                    end
+                Error={error, _} ->
+                    Error
             end;
         Error={error, _} ->
             Error
@@ -538,6 +534,8 @@ to_list(X)
   when erlang:is_list(X) ->
     X.
 
+help(package) ->
+    "Specifies the package to use with the publish command, currently only utilized in a revert operation";
 help(revert) ->
     "Revert given version, if the last version is reverted the package is removed";
 help(replace) ->
@@ -545,22 +543,22 @@ help(replace) ->
     "packages can always be overwritten, publicpackages can only be "
     "overwritten within one hour after they were initially published.";
 help(yes) ->
-    "Publishes the package without any confirmation prompts".
+    "Publishes the package without any confirmation prompts";
+help(without_docs) ->
+    "Publishing a package without publishing documentation that may be automatically generated".
 
 support() ->
     "Publishes a new version of a package with options to revert and replace existing packages~n~n"
     "Supported commmand combinations:~n~n"
     "  rebar3 hex publish~n~n"
-    "  rebar3 hex publish package~n~n"
     "  rebar3 hex publish --yes~n~n"
-    "  rebar3 hex publish package~n~n"
-    "  rebar3 hex publish docs~n~n"
     "  rebar3 hex publish --repo <repo>~n~n"
     "  rebar3 hex publish --repo <repo> --yes~n~n"
-    "  rebar3 hex publish --revert <version>~n~n"
-    "  rebar3 hex publish --revert <version> --yes~n~n"
+    "  rebar3 hex publish --revert <version> --package <package>~n~n"
+    "  rebar3 hex publish --revert <version> --package <package> --yes~n~n"
     "  rebar3 hex publish --replace~n~n"
     "  rebar3 hex publish --replace --yes~n~n"
     "Argument descriptions:~n~n"
     "  <repo>    - a valid repository, only required when multiple repositories are configured~n~n"
-    "  <version> - a valid version string, currently only utilized with --revert switch~n~n".
+    "  <version> - a valid version string, currently only utilized with --revert switch~n~n"
+    "  <package> - a valid package name, currently only utilized with --revert switch~n~n".

--- a/test/rebar3_hex_SUITE.erl
+++ b/test/rebar3_hex_SUITE.erl
@@ -5,7 +5,8 @@
 -include_lib("eunit/include/eunit.hrl").
 
 all() ->
-    [task_args_test, task_state_test, gather_opts_test, init_test, help_test, repo_opt].
+    [task_args_test, gather_opts_test, init_test, help_test, repo_opt].
+
 
 gather_opts_test(_Config) ->
     State = rebar_state:new(),
@@ -21,15 +22,6 @@ task_args_test(_Config) ->
     CmdArgs2 = {[{foo,"bar"}, {count, 42}], []},
     State2 = rebar_state:command_parsed_args(State, CmdArgs2),
     ?assertMatch({undefined,[{foo,"bar"},{count,42}]}, rebar3_hex:task_args(State2)).
-
-task_state_test(_Config) ->
-    State = rebar_state:new(),
-    CmdArgs = {[{task, "thing"}, {foo,"bar"}, {count, 42}], ["bar"]},
-    State1 = rebar_state:command_parsed_args(State, CmdArgs),
-    ?assertMatch(#{count := 42, foo := "bar", task := thing, bar := true}, rebar3_hex:get_args(State1)),
-    CmdArgs2 = {[{foo,false}, {count, 42}], []},
-    State2 = rebar_state:command_parsed_args(State, CmdArgs2),
-    ?assertMatch(#{count := 42, foo := false}, rebar3_hex:get_args(State2)).
 
 repo_opt(_Config) ->
     ?assertEqual({repo,114,"repo",string,

--- a/test/rebar3_hex_integration_SUITE.erl
+++ b/test/rebar3_hex_integration_SUITE.erl
@@ -51,7 +51,6 @@ all() ->
     , publish_error_test
     , publish_unauthorized_test
     , publish_without_docs_test
-    , publish_only_docs_test
     , key_list_test
     , key_get_test
     , key_add_test
@@ -499,7 +498,7 @@ publish_revert_test(Config) ->
     P = #{app => "valid", mocks => [publish_revert], version => "1.0.0"},
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
     RepoConfig = [{repos,[Repo]}],
-    {ok, PubState} = test_utils:mock_command(rebar3_hex_publish, ["--revert", "1.0.0"], RepoConfig, State),
+    {ok, PubState} = test_utils:mock_command(rebar3_hex_publish, ["--revert", "1.0.0", "--package", "valid"], RepoConfig, State),
 
     ?assertMatch({ok, PubState}, rebar3_hex_publish:do(PubState)).
 
@@ -565,16 +564,8 @@ publish_without_docs_test(Config) ->
     P = #{app => "valid", mocks => [publish]},
     {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
     RepoConfig = [{repos,[Repo]}],
-    {ok, PubState} = test_utils:mock_command(rebar3_hex_publish, ["package"], RepoConfig, State),
+    {ok, PubState} = test_utils:mock_command(rebar3_hex_publish, ["--without-docs"], RepoConfig, State),
     ?assertMatch({ok, PubState}, rebar3_hex_publish:do(PubState)).
-
-publish_only_docs_test(Config) ->
-    P = #{app => "valid", mocks => [publish]},
-    {ok, #{rebar_state := State, repo := Repo}} = setup_state(P, Config),
-    RepoConfig = [{repos,[Repo]}], 
-    {ok, PubState} = test_utils:mock_command(rebar3_hex_publish, ["docs"], RepoConfig, State), 
-    {ok, NewState} = rebar_prv_edoc:do(PubState),
-    ?assertMatch({ok, PubState}, rebar3_hex_publish:do(NewState)).
 
 key_list_test(Config) ->
     P = #{app => "valid", mocks => []},

--- a/test/support/test_utils.erl
+++ b/test/support/test_utils.erl
@@ -26,8 +26,7 @@ mock_app(AppName, DataDir, Repo) ->
     State = rebar_state:new(), 
     {ok, App} = rebar_app_info:discover(Src, State),
     State1 = rebar_state:project_apps(rebar_state(Repo), [App]),
-    State2 = rebar_state:current_app(State1, App),
-    {ok, App, State2}.
+    {ok, App, State1}.
 
 mock_command(ProviderName, Command, RepoConfig, State0) ->
     State1 = rebar_state:add_resource(State0, {pkg, rebar_pkg_resource}),


### PR DESCRIPTION
Reverts erlef/rebar3_hex#235

Adding the options is fine but don't remove umbrella publishing. This is an important feature that without makes having multiple apps in a repo more painful. Maybe it needs some work? But removing it is not a good solution to any issues it may have.