### PR TITLE
Restore release (umbrella) publish support

### DIFF
--- a/src/rebar3_hex.erl
+++ b/src/rebar3_hex.erl
@@ -10,7 +10,7 @@
         , help_opt/0
         ]).
 
--type task() :: #{args := map(), repo := map(), state := rebar_state:t(), multi_project := boolean()}.
+-type task() :: #{args := map(), repo := map(), state := rebar_state:t(), multi_app := boolean()}.
 
 -export_type([task/0]).
 

--- a/src/rebar3_hex.erl
+++ b/src/rebar3_hex.erl
@@ -62,7 +62,13 @@ task_state(State) ->
      case rebar3_hex_config:repo(State) of
          {ok, Repo} -> 
              Opts = get_args(State),
-             {ok, #{args => Opts, repo => Repo, state => State}};
+             case rebar_state:project_apps(State) of 
+                 [App] ->
+                     State1 = rebar_state:current_app(State, App),
+                    {ok, #{args => Opts, repo => Repo, state => State1, multi_project => false}};
+                 [_|_] -> 
+                    {ok, #{args => Opts, repo => Repo, state => State, multi_project => true}}
+             end;
          Err -> 
             Err
      end.

--- a/src/rebar3_hex.erl
+++ b/src/rebar3_hex.erl
@@ -10,7 +10,7 @@
         , help_opt/0
         ]).
 
--type task() :: #{args := map(), repo := map(), state := rebar_state:t()}.
+-type task() :: #{args := map(), repo := map(), state := rebar_state:t(), multi_project := boolean()}.
 
 -export_type([task/0]).
 

--- a/src/rebar3_hex.erl
+++ b/src/rebar3_hex.erl
@@ -65,9 +65,9 @@ task_state(State) ->
              case rebar_state:project_apps(State) of 
                  [App] ->
                      State1 = rebar_state:current_app(State, App),
-                    {ok, #{args => Opts, repo => Repo, state => State1, multi_project => false}};
+                    {ok, #{args => Opts, repo => Repo, state => State1, multi_app => false}};
                  [_|_] -> 
-                    {ok, #{args => Opts, repo => Repo, state => State, multi_project => true}}
+                    {ok, #{args => Opts, repo => Repo, state => State, multi_app => true}}
              end;
          Err -> 
             Err

--- a/src/rebar3_hex_publish.erl
+++ b/src/rebar3_hex_publish.erl
@@ -563,7 +563,7 @@ to_list(X)
 
 help(app) ->
     "Specifies the app to use with the publish command, currently only utilized for publish and revert operations"
-    "Note the app switch and value only has to be provided if you are publishing within a release (umbrella).";
+    "Note that the app switch and value only have to be provided if you are publishing within a release (umbrella).";
 help(revert) ->
     "Revert given version, if the last version is reverted the package is removed";
 help(replace) ->

--- a/src/rebar3_hex_publish.erl
+++ b/src/rebar3_hex_publish.erl
@@ -70,24 +70,24 @@ do(State) ->
 handle_task(#{args := #{revert := undefined}}) ->
     {error, "--revert requires an app version"};
 
-handle_task(#{args := #{revert := Vsn}, multi_project := false} = Task) ->
+handle_task(#{args := #{revert := Vsn}, multi_app := false} = Task) ->
     #{repo := Repo, state := State} = Task,
     App = rebar_state:current_app(State),
     Name = rebar_app_info:name(App),
     ok = rebar3_hex_revert:revert(binarify(Name), binarify(Vsn), Repo, State),
     {ok, State};
 
-handle_task(#{args := #{revert := Vsn, app := AppName}, multi_project := true} = Task) ->
+handle_task(#{args := #{revert := Vsn, app := AppName}, multi_app := true} = Task) ->
     #{repo := Repo, state := State} = Task,
     ok = rebar3_hex_revert:revert(binarify(AppName), binarify(Vsn), Repo, State),
     {ok, State};
 
-handle_task(#{args := #{revert := _}, multi_project := true}) ->
+handle_task(#{args := #{revert := _}, multi_app := true}) ->
     {error, "--app required when reverting in a release with multiple projects"};
 
 %% Publish 
 
-handle_task(#{repo := Repo, state := State, multi_project := false}) -> 
+handle_task(#{repo := Repo, state := State, multi_app := false}) -> 
     case maps:get(write_key, Repo, maps:get(api_key, Repo, undefined)) of
             undefined ->
                 ?PRV_ERROR(no_write_key);
@@ -96,7 +96,7 @@ handle_task(#{repo := Repo, state := State, multi_project := false}) ->
                 publish(App, Repo, State)
         end;
 
-handle_task(#{repo := Repo, state := State, multi_project := true}) ->
+handle_task(#{repo := Repo, state := State, multi_app := true}) ->
         case maps:get(write_key, Repo, maps:get(api_key, Repo, undefined)) of
             undefined ->
                 ?PRV_ERROR(no_write_key);

--- a/src/rebar3_hex_publish.erl
+++ b/src/rebar3_hex_publish.erl
@@ -563,7 +563,7 @@ to_list(X)
 
 help(app) ->
     "Specifies the app to use with the publish command, currently only utilized for publish and revert operations"
-    "Note that the app switch and value only have to be provided if you are publishing within a release (umbrella).";
+    "Note that the app switch and value only have to be provided if you are publishing within an umbrella.";
 help(revert) ->
     "Revert given version, if the last version is reverted the package is removed";
 help(replace) ->

--- a/src/rebar3_hex_publish.erl
+++ b/src/rebar3_hex_publish.erl
@@ -87,16 +87,16 @@ handle_task(#{args := #{revert := _}, multi_project := true}) ->
 
 %% Publish 
 
-handle_task(#{repo := Repo, state := State, is_release := false}) -> 
+handle_task(#{repo := Repo, state := State, multi_project := false}) -> 
     case maps:get(write_key, Repo, maps:get(api_key, Repo, undefined)) of
             undefined ->
                 ?PRV_ERROR(no_write_key);
             _ ->
                 App = rebar_state:current_app(State),
                 publish(App, Repo, State)
-        end.
+        end;
 
-handle_task(#{repo := Repo, state := State, is_release := true}) ->
+handle_task(#{repo := Repo, state := State, multi_project := true}) ->
         case maps:get(write_key, Repo, maps:get(api_key, Repo, undefined)) of
             undefined ->
                 ?PRV_ERROR(no_write_key);

--- a/src/rebar3_hex_publish.erl
+++ b/src/rebar3_hex_publish.erl
@@ -83,7 +83,7 @@ handle_task(#{args := #{revert := Vsn, app := AppName}, multi_app := true} = Tas
     {ok, State};
 
 handle_task(#{args := #{revert := _}, multi_app := true}) ->
-    {error, "--app required when reverting in a release with multiple projects"};
+    {error, "--app required when reverting in a umbrella with multiple apps"};
 
 %% Publish 
 


### PR DESCRIPTION
Obsoletes #240 

This is the bare minimum to restore support for publishing from the top level of a release. That is to say, it essentially
puts things back how they were vs including refactors that will happen in this module.

- Restore support for publishing multiple apps in a release
- Add --app switch which acts as the old --package switch did (required for reverting a specific app)
- Set the current_app in rebar state via rebar3_hex:task_state/1 so that rebar_state:current_app/1
  may be utilized when not in a release.
- Set a multi_project k/v (boolean) in rebar3_hex:task_state/1