### PR TITLE
Change api domain value to binary in rebar3_hex_user

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -16,7 +16,7 @@
     {test, [
         {extra_src_dirs, ["test/support"]},
         {overrides, [{override, rebar3,[{deps, [{erlware_commons, "1.3.1"}]}]}]},
-        {deps, [{hex_core, "0.7.1"},
+        {deps, [{hex_core, "0.8.2"},
                 {erlware_commons, "1.5.0"}, {elli, "3.3.0"},
                 {jsone, "1.5.3"}, {meck, "0.9.0"}]},
         {erl_opts, [nowarn_export_all]}

--- a/src/rebar3_hex_user.erl
+++ b/src/rebar3_hex_user.erl
@@ -212,7 +212,7 @@ generate_all_keys(Username, Password, LocalPassword, Repo, State) ->
 
     %% write key
     WriteKeyName = api_key_name(),
-    WritePermissions = [#{domain => api}],
+    WritePermissions = [#{domain => <<"api">>}],
     case generate_key(RepoConfig0, WriteKeyName, WritePermissions) of
         {ok, WriteKey} ->
 

--- a/src/rebar3_hex_user.erl
+++ b/src/rebar3_hex_user.erl
@@ -203,7 +203,7 @@ pad(Binary) ->
             <<Binary/binary, 0:((32 - Size) * 8)>>
     end.
 
--dialyzer({no_return, generate_all_keys/5}).
+-dialyzer({nowarn_function, generate_all_keys/5}).
 generate_all_keys(Username, Password, LocalPassword, Repo, State) ->
     rebar3_hex_io:say("Generating all keys..."),
 
@@ -289,6 +289,7 @@ cipher(Key) when byte_size(Key) == 24  -> aes_192_gcm;
 cipher(Key) when byte_size(Key) == 32  -> aes_256_gcm.
 -endif.
 
+-dialyzer({nowarn_function, generate_key/3}).
 generate_key(RepoConfig, KeyName, Permissions) ->
     case hex_api_key:add(RepoConfig, KeyName, Permissions) of
         {ok, {201, _Headers, #{<<"secret">> := Secret}}} ->
@@ -306,9 +307,11 @@ hostname() ->
 api_key_name() ->
     list_to_binary(hostname()).
 
+-dialyzer({nowarn_function, api_key_name/1}).
 api_key_name(Postfix) ->
     list_to_binary([hostname(), "-api-", Postfix]).
 
+-dialyzer({nowarn_function, repos_key_name/0}).
 repos_key_name() ->
     list_to_binary([hostname(), "-repositories"]).
 


### PR DESCRIPTION
The domain value for write permissions should be a binary vs an atom.

Since upgrading to hex_core 0.8.2 the domain value must be a binary instead of an atom. I say hex_core 0.8.2 as that's the only thing that has changed. It's possible something changed on hexpm side as well, regardless, it should not be an atom 😁 

Edit:

It's not hex_core, hex_core still has the value defined as an atom, but it doesn't get converted, and hexpm wants a binary, not an atom. May be a bug in hex_core. 
