### PR TITLE
Fix crash for "no version for docs"

### DIFF
--- a/src/rebar3_hex_docs.erl
+++ b/src/rebar3_hex_docs.erl
@@ -67,6 +67,8 @@ format_error({revert, {unauthorized, _Res}}) ->
     "Error reverting docs : Not authorized";
 format_error({revert, {not_found, _Res}}) ->
     "Error reverting docs : Package or Package Version not found";
+format_error({publish, {error, #{ <<"status">> := 404 }}}) ->
+    "Error publishing : Package or Package Version not found";
 format_error(Reason) ->
     rebar3_hex_error:format_error(Reason).
 

--- a/src/rebar3_hex_error.erl
+++ b/src/rebar3_hex_error.erl
@@ -21,5 +21,5 @@ format_error({Cmd, missing_required_params}) ->
     io_lib:format("Required parameters for the ~ts command have not been supplied.", [Cmd]);
 
 format_error(Reason) ->
-    rebar_api:debug("Unknown error : ~ps", [Reason]),
+    rebar_api:debug("Unknown error: ~p", [Reason]),
     "An unknown error was encountered. Run with DEBUG=1 for more details.".


### PR DESCRIPTION
This was crashing: I'm not sure whether that's the message you want, though, in `rebar3_hex_docs`.

Bonus fix was removing an extra `s` from a log message (in `rebar3_hex_error`).

Also, should `rebar3_hex_error`'s `format_error(Reason)` return a string so as to not crash? Or is the crash intended, here?