### PR TITLE
Change api domain value to binary in rebar3_hex_user (#242)

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -16,7 +16,7 @@
     {test, [
         {extra_src_dirs, ["test/support"]},
         {overrides, [{override, rebar3,[{deps, [{erlware_commons, "1.3.1"}]}]}]},
-        {deps, [{hex_core, "0.7.1"},
+        {deps, [{hex_core, "0.8.2"},
                 {erlware_commons, "1.5.0"}, {elli, "3.3.0"},
                 {jsone, "1.5.3"}, {meck, "0.9.0"}]},
         {erl_opts, [nowarn_export_all]}


### PR DESCRIPTION
The domain value for write permissions should be a binary vs an atom.

 -  Ignore some functions temporarily and bump hex_core to 0.8.2 in test