### PR TITLE
Gracefully handle required missing retire arguments

### DIFF
--- a/src/rebar3_hex_retire.erl
+++ b/src/rebar3_hex_retire.erl
@@ -47,15 +47,24 @@ do(State) ->
 
 handle_command(State, Repo) ->
     {Args, _} = rebar_state:command_parsed_args(State),
-    Name = rebar3_hex:get_required(pkg, Args),
+    Name = get_required_or_raise(pkg, Args),
+    Version = get_required_or_raise(vsn, Args),
+    Reason = get_required_or_raise(reason, Args),
+    Message = get_required_or_raise(message, Args),
     PkgName = rebar_utils:to_binary(Name),
-    Version = rebar3_hex:get_required(vsn, Args),
-    Reason = rebar3_hex:get_required(reason, Args),
-    Message = rebar3_hex:get_required(message, Args),
     retire(PkgName, rebar_utils:to_binary(Version), Repo,
            rebar_utils:to_binary(Reason),
            rebar_utils:to_binary(Message),
            State).
+
+
+get_required_or_raise(Key, Args) ->
+    case rebar3_hex:get_required(Key, Args) of
+            {error, Err} ->
+                erlang:error(?PRV_ERROR(Err));
+            Res ->
+                Res
+    end.
 
 errors_to_string(Value) when is_binary(Value) ->
     Value;

--- a/test/support/hex_api_model.erl
+++ b/test/support/hex_api_model.erl
@@ -146,7 +146,7 @@ handle('POST', [<<"packages">>,_Name,<<"releases">>,_Ver,<<"retire">>], Req) ->
        unauthorized ->
             respond_with(403, Req, #{<<"message">> => <<"account not authorized for this action">>});
         error ->
-           respond_with(401, Req, #{})
+            respond_with(401, Req, #{})
    end;
 
 handle('POST', [<<"keys">>], Req) ->

--- a/test/support/hex_api_model.erl
+++ b/test/support/hex_api_model.erl
@@ -139,6 +139,16 @@ handle('POST', [<<"repos">>, _Repo, <<"publish">>], Req) ->
            respond_with(401, Req, #{})
    end;
 
+handle('POST', [<<"packages">>,_Name,<<"releases">>,_Ver,<<"retire">>], Req) ->
+    case authenticate(Req) of
+       {ok, #{username := _Username, email := _Email}} ->
+            {204, [{<<"Content-type">>, "text/plain"}], <<>>};
+       unauthorized ->
+            respond_with(403, Req, #{<<"message">> => <<"account not authorized for this action">>});
+        error ->
+           respond_with(401, Req, #{})
+   end;
+
 handle('POST', [<<"keys">>], Req) ->
     Data     = body_to_terms(Req),
     _Name = maps:get(<<"name">>, Data),
@@ -263,7 +273,7 @@ handle('DELETE', [<<"keys">>, <<"key">>], Req) ->
     Res = #{<<"secret">> => <<"repo_key">>},
     respond_with(200, Req, Res);
 
-handle(_, _Path, Req) ->
+handle(_Method, _Path, Req) ->
     respond_with(404, Req, #{}).
 
 handle_event(_Event, _Data, _Args) ->


### PR DESCRIPTION
Closes #253 

- Add helper function in rebar3_hex_retire that gets a required param or raises
- add basic tests for retire in integration suite
- add post retirement route support in hex api model