### PR TITLE
Remove fail fast matches

### DIFF
--- a/src/rebar3_hex_client.erl
+++ b/src/rebar3_hex_client.erl
@@ -79,9 +79,7 @@ delete_release(HexConfig, Name, Version) ->
     Res = hex_api_release:delete(HexConfig, Name, Version),
     response(Res).
 
-publish_docs(Repo, Name, Version, Tarball) ->
-    {ok, Config} = rebar3_hex_config:hex_config_write(Repo),
-
+publish_docs(Config, Name, Version, Tarball) ->
     TarballContentType = "application/octet-stream",
 
     Headers = maps:get(http_headers, Config, #{}),

--- a/src/rebar3_hex_config.erl
+++ b/src/rebar3_hex_config.erl
@@ -7,9 +7,7 @@
         , repos_key_name/0
         , org_key_name/2
         , parent_repos/1
-        , hex_config/2
-        , hex_config_write/1
-        , hex_config_read/1
+        , get_hex_config/3
         , repo/1
         , repo/2
         , update_auth_config/2
@@ -194,7 +192,7 @@ parent_repos(State) ->
                   end
           end,
     Map = lists:foldl(Fun, #{}, Repos),
-    {ok, maps:values(Map)}.
+    maps:values(Map).
 
 get_repo(BinaryName, Repos) ->
     try rebar_hex_repos:get_repo_config(BinaryName, Repos) of
@@ -202,6 +200,15 @@ get_repo(BinaryName, Repos) ->
             Name
     catch
         {error,{rebar_hex_repos,{repo_not_found,BinaryName}}} -> undefined
+    end.
+
+-spec get_hex_config(module(), map(), read | write) -> map().
+get_hex_config(Module, Repo, Mode) ->
+    case hex_config(Repo, Mode) of
+        {ok, HexConfig} ->
+            HexConfig;
+        {error, Reason} ->
+            erlang:error({error, {Module, {get_hex_config, Reason}}})
     end.
 
 hex_config(Repo, read) ->

--- a/src/rebar3_hex_error.erl
+++ b/src/rebar3_hex_error.erl
@@ -5,11 +5,11 @@
 format_error({required, repo}) ->
     "A repository argument is required for this command.";
 
-format_error({error, no_read_key}) ->
+format_error({get_hex_config, no_read_key}) ->
     "No read key found for user. Be sure to authenticate first with:"
     " rebar3 hex user auth";
 
-format_error({error, no_write_key}) ->
+format_error({get_hex_config, no_write_key}) ->
     "No write key found for user. Be sure to authenticate first with:"
     " rebar3 hex user auth";
 

--- a/src/rebar3_hex_organization.erl
+++ b/src/rebar3_hex_organization.erl
@@ -144,10 +144,6 @@ format_error(no_repo) ->
 format_error(auth_no_key) ->
     "Repo authenticate command requires key";
 
-format_error({get_write_config, {error, no_write_key}}) -> 
-    "You are not authenticated to the parent repository as a user. " 
-    "Authenticate with rebar3 hex user auth then run this command again.";
-
 format_error({auth, Reason}) when is_binary(Reason) ->
     io_lib:format("Error authenticating organization : ~ts", [Reason]);
 format_error({auth, Errors}) when is_map(Errors) ->
@@ -207,7 +203,7 @@ auth(State, RepoName) ->
     Key =
         case proplists:get_value(key, Opts, undefined) of
             undefined ->
-                Config = get_write_config(ParentRepo),
+                Config = rebar3_hex_config:get_hex_config(?MODULE, ParentRepo, write),
                 Config1 = Config#{api_organization => OrgName},
                 KeyName = proplists:get_value(key_name, Opts, rebar3_hex_config:repos_key_name()),
                 generate_key(Config1, KeyName, default_perms(OrgName));
@@ -239,7 +235,7 @@ generate(State, RepoName) ->
     {Repo, OrgName} = get_parent_repo_and_org_name(State, RepoName),
     {Opts, _} = rebar_state:command_parsed_args(State),
     KeyName = proplists:get_value(key_name, Opts, rebar3_hex_config:repos_key_name()),
-    Config = get_write_config(Repo),
+    Config = rebar3_hex_config:get_hex_config(?MODULE, Repo, write),
     PermOpts = proplists:get_all_values(permission, Opts),
     Perms = rebar3_hex_key:convert_permissions(PermOpts, default_perms(OrgName)),
     Key = generate_key(Config#{api_organization => OrgName}, KeyName, Perms),
@@ -249,7 +245,7 @@ generate(State, RepoName) ->
 -spec list_org_keys(rebar_state:t(), binary()) -> {ok, rebar_state:t()}.
 list_org_keys(State, RepoName) ->
     {Repo, OrgName} = get_parent_repo_and_org_name(State, RepoName),
-    Config = get_write_config(Repo),
+    Config = rebar3_hex_config:get_hex_config(?MODULE, Repo, read),
     case rebar3_hex_key:list(Config#{api_organization => OrgName}) of
         ok ->
             {ok, State};
@@ -271,7 +267,7 @@ revoke(State, RepoName) ->
                   K ->
                       K
               end,
-    Config = get_write_config(Repo),
+    Config = rebar3_hex_config:get_hex_config(?MODULE, Repo, write),
     case rebar3_hex_key:revoke(Config#{api_organization => OrgName}, KeyName) of
         ok ->
             rebar3_hex_io:say("Key successfully revoked", []),
@@ -287,7 +283,7 @@ revoke(State, RepoName) ->
 -spec revoke_all(rebar_state:t(), binary()) -> {ok, rebar_state:t()}.
 revoke_all(State, RepoName) ->
     {Repo, OrgName} = get_parent_repo_and_org_name(State, RepoName),
-    Config = get_write_config(Repo),
+    Config = rebar3_hex_config:get_hex_config(?MODULE, Repo, write),
     case rebar3_hex_key:revoke_all(Config#{api_organization => OrgName}) of
         ok ->
             rebar3_hex_io:say("All keys successfully revoked", []),
@@ -382,15 +378,6 @@ to_binary(Name) ->
 
 -spec org_url(binary(), binary()) -> [byte(), ...].
 org_url(Org, Url) -> binary_to_list(Url) ++ "/repos/" ++ binary_to_list(Org).
-
--spec get_write_config(map()) -> map().
-get_write_config(Repo) ->
-    case rebar3_hex_config:hex_config_write(Repo) of
-        {ok, HexConfig} ->
-            HexConfig;
-        Error ->
-            ?RAISE({get_write_config, Error})
-    end.
 
 get_parent_repo_and_org_name(State, RepoName) ->
     case binary:split(RepoName, <<":">>) of

--- a/src/rebar3_hex_publish.erl
+++ b/src/rebar3_hex_publish.erl
@@ -61,10 +61,6 @@ format_error(ErrList) when is_list(ErrList) ->
   More = "\n     Please see https://hex.pm/docs/rebar3_publish for more info.\n",
   lists:foldl(F, "Validator Errors:\n", ErrList) ++ More;
 
-format_error(no_write_key) ->
-    "No write key found for user. Be sure to authenticate first with:"
-    ++ " rebar3 hex user auth";
-
 format_error(no_apps_found) ->
     "publish can not continue, no apps were found.";
 
@@ -218,7 +214,7 @@ handle_task(#{args := #{task := package, revert := Vsn}, apps := [App]} = Task) 
 handle_task(#{args := #{task := package}, apps := [App]} = Task) ->
     maybe_warn_about_single_app_args(Task),
     #{args := Args, repo := Repo, state := State} = Task,
-    {ok, HexConfig} = write_config(Repo),
+    HexConfig = rebar3_hex_config:get_hex_config(?MODULE, Repo, write),
     rebar_api:info("package argument given, will not publish docs", []),
     publish_package(State, HexConfig, App, Args);
 
@@ -228,7 +224,7 @@ handle_task(#{args := #{task := package, app := AppName}, apps := Apps} = Task) 
         {error, app_not_found} ->
             ?RAISE({app_not_found, AppName});
         {ok, App} ->
-            {ok, HexConfig} = write_config(Repo),
+            HexConfig = rebar3_hex_config:get_hex_config(?MODULE, Repo, write),
             rebar_api:info("package argument given, will not publish docs", []),
             publish_package(State, HexConfig, App, Args)
     end,
@@ -307,7 +303,7 @@ handle_task(_) ->
 
 -dialyzer({nowarn_function, publish/4}).
 publish(State, Repo, App, Args) ->
-    {ok, HexConfig} = write_config(Repo),
+    HexConfig = rebar3_hex_config:get_hex_config(?MODULE, Repo, write),
     case publish_package(State, HexConfig, App, Args) of
         abort ->
             {ok, State};
@@ -431,7 +427,8 @@ publish_docs(State, Repo, App, Args) ->
             rebar_api:info("--dry-run enabled : will not publish docs.", []),
             {ok, State};
          _ ->
-            case rebar3_hex_client:publish_docs(Repo, Name, Vsn, Tar) of
+            Config = rebar3_hex_config:get_hex_config(?MODULE, Repo, write),
+            case rebar3_hex_client:publish_docs(Config, Name, Vsn, Tar) of
                 {ok, _} ->
                     rebar_api:info("Published docs for ~ts ~ts", [Name, Vsn]),
                     {ok, State};
@@ -458,7 +455,7 @@ revert_package(State, Repo, AppName, Vsn) ->
     BinAppName = rebar_utils:to_binary(AppName),
     BinVsn =  rebar_utils:to_binary(Vsn),
     assert_valid_version_arg(BinVsn),
-    {ok, HexConfig} = write_config(Repo),
+    HexConfig = rebar3_hex_config:get_hex_config(?MODULE, Repo, write),
     case rebar3_hex_client:delete_release(HexConfig, BinAppName, BinVsn) of
         {ok, _} ->
             rebar_api:info("Successfully deleted package ~ts ~ts", [AppName, Vsn]),
@@ -477,7 +474,7 @@ revert_docs(State, Repo, AppName, Vsn) ->
     BinAppName = rebar_utils:to_binary(AppName),
     BinVsn =  rebar_utils:to_binary(Vsn),
     assert_valid_version_arg(BinVsn),
-    {ok, Config} = write_config(Repo),
+    Config = rebar3_hex_config:get_hex_config(?MODULE, Repo, write),
     case rebar3_hex_client:delete_docs(Config, BinAppName, BinVsn) of
         {ok, _} ->
             rebar_api:info("Successfully deleted docs for ~ts ~ts", [AppName, Vsn]),
@@ -489,15 +486,6 @@ revert_docs(State, Repo, AppName, Vsn) ->
 %% ===================================================================
 %% General purpose helpers
 %% ===================================================================
-
-assert_has_write_key(Repo) ->
-    MaybeApiKey = maps:get(api_key, Repo, undefined),
-    case maps:get(write_key, Repo, MaybeApiKey) of
-        undefined ->
-            ?RAISE(no_write_key);
-        _ ->
-            ok
-    end.
 
 assert_valid_app(State, App) ->
     Name = rebar_app_info:name(App),
@@ -580,6 +568,3 @@ support() ->
     "  <repo>    - a valid repository, only required when multiple repositories are configured~n~n"
     "  <version> - a valid version string, currently only utilized with --revert switch~n~n".
 
-write_config(Repo) ->
-    assert_has_write_key(Repo),
-    rebar3_hex_config:hex_config_write(Repo).

--- a/src/rebar3_hex_search.erl
+++ b/src/rebar3_hex_search.erl
@@ -30,12 +30,12 @@ init(State) ->
 do(State) ->
     {Args, _} = rebar_state:command_parsed_args(State),
     Term = proplists:get_value(term, Args, ""),
-    {ok, Parents} = rebar3_hex_config:parent_repos(State),
+    Parents = rebar3_hex_config:parent_repos(State),
     lists:foreach(fun(Repo) -> search(State, Repo, Term) end, Parents),
     {ok, State}.
 
 search(State, Repo, Term) ->
-    {ok, HexConfig} = rebar3_hex_config:hex_config_read(Repo),
+    HexConfig = rebar3_hex_config:get_hex_config(?MODULE, Repo, read),
     case hex_api_package:search(HexConfig, rebar_utils:to_binary(Term), []) of
         {ok, {200, _Headers, []}} ->
             io:format("No Results~n"),

--- a/test/rebar3_hex_integration_SUITE.erl
+++ b/test/rebar3_hex_integration_SUITE.erl
@@ -873,7 +873,7 @@ publish_error_test(Config) ->
          },
     #{rebar_state := State} = Setup = setup_state(P, Config),
     expects_repo_config(Setup),
-    ?assertError({error,{rebar3_hex_publish,no_write_key}}, rebar3_hex_publish:do(State)).
+    ?assertError({error,{rebar3_hex_publish,{get_hex_config, no_write_key}}}, rebar3_hex_publish:do(State)).
 
 publish_unauthorized_test(Config) ->
     WriteKey = rebar3_hex_user:encrypt_write_key(<<"mr_pockets">>, <<"special_shoes">>, <<"unauthorized">>),
@@ -1311,7 +1311,7 @@ expects_repo_config(#{repo := Repo}) ->
     meck:expect(rebar3_hex_config, repo, fun(_, <<"hexpm">>) -> {ok, test_utils:default_config()} end).
 
 expects_parent_repos(#{repo := Repo}) ->
-    meck:expect(rebar3_hex_config, parent_repos, fun(_) -> {ok, [Repo]} end).
+    meck:expect(rebar3_hex_config, parent_repos, fun(_) -> [Repo] end).
 
 expects_update_auth_config( #{username := Username, repo := Repo}) ->
     BinUsername = rebar_utils:to_binary(Username),

--- a/test/rebar3_hex_publish_SUITE.erl
+++ b/test/rebar3_hex_publish_SUITE.erl
@@ -27,7 +27,7 @@ format_error_test(_Config) ->
         {{no_license, myapp}, <<"myapp.app.src : missing or empty licenses property">>},
         {{has_maintainers, myapp}, <<"myapp.app.src : deprecated field maintainers found">>},
         {{has_contributors, myapp}, <<"myapp.app.src : deprecated field contributors found">>},
-        {no_write_key,
+        {{get_hex_config, no_write_key},
             <<"No write key found for user. Be sure to authenticate first with: rebar3 hex user auth">>},
 
 


### PR DESCRIPTION
Removed most fail fast pattern matches in an effort to not crash and provide
a better developer experience.

- Added rebar3_hex_config:get_hex_config/3
- Added rebar3_hex_error:format_error/1 clauses per get_hex_config/3
- Removed hex_config/2, hex_config_write/1, and hex_config_read/1 from
  rebar3_hex_config exports
- Removed existing helpers and obsoloete format_error/1 clauses
  on providers in favor of rebar3_hex_config:get_hex_config/3