### PR TITLE
Handle known all errors we raise

### DIFF
--- a/src/rebar3_hex_error.erl
+++ b/src/rebar3_hex_error.erl
@@ -5,11 +5,14 @@
 format_error({required, repo}) ->
     "A repository argument is required for this command.";
 
-format_error({error, no_read_key}) ->
+format_error({not_valid_repo, RepoName}) ->
+    io_lib:format("Could not find ~ts in repo configuration. Be sure to authenticate first with rebar3 hex user auth.",
+                  [RepoName]);
+format_error({get_hex_config, no_read_key}) ->
     "No read key found for user. Be sure to authenticate first with:"
     " rebar3 hex user auth";
 
-format_error({error, no_write_key}) ->
+format_error({get_hex_config, no_write_key}) ->
     "No write key found for user. Be sure to authenticate first with:"
     " rebar3 hex user auth";
 

--- a/src/rebar3_hex_organization.erl
+++ b/src/rebar3_hex_organization.erl
@@ -192,6 +192,10 @@ format_error(not_a_valid_repo_name) ->
     "Invalid organization repository: organization name arguments must be given as a fully qualified "
     "repository name (i.e, hexpm:my_org)";
 
+format_error({get_parent_repo_and_org_name, Error, Name}) -> 
+    Str = "Error getting the parent repo for ~ts. Be sure to authenticate first with: rebar3 hex user",
+    rebar_log:log(diagnostic, "Error getting parent repo and org name: ~p", [Error]),
+    io_lib:format(Str, [Name]);
 format_error({get_repo_by_name, {error,{not_valid_repo,ParentName}}}) ->
     Str = io_lib:format("You do not appear to be authenticated as a user to the ~ts repository.", [ParentName]),
     Str ++  " " ++ "Run rebar3 hex user auth and try this command again.";
@@ -399,7 +403,7 @@ get_parent_repo_and_org_name(State, RepoName) ->
                 {ok, Repo} ->
                     {Repo, Org};
                 Error ->
-                    ?RAISE({get_parent_repo_and_org_name, Error})
+                    ?RAISE({get_parent_repo_and_org_name, Error, RepoName})
             end;
         [_] ->
             ?RAISE(not_a_valid_repo_name)


### PR DESCRIPTION
Technically, this just covers a few cases where we would have asked the user to run with `DIAGNOSTIC=1`. A huge sweep should be done to standardize on what we raise and how we handle it, but I think that should be saved for 7.1.0 