### PR TITLE
rebar3_hex_organization: allow building with OTP-25.0-rc1

### DIFF
--- a/src/rebar3_hex_organization.erl
+++ b/src/rebar3_hex_organization.erl
@@ -377,15 +377,17 @@ printable_public_key(PubKey) ->
     "SHA256:" ++ Encoded.
 
 
--ifdef(OTP_23).
--spec ssh_encode(binary()) -> binary().
-ssh_encode(InData) ->
-    public_key:ssh_encode(InData, ssh2_pubkey).
--elif(POST_OTP_22 and not OTP_23).
+-ifdef(OTP_RELEASE). % OTP >= 21
+-if(?OTP_RELEASE >= 24).
 -spec ssh_encode(binary()) -> binary().
 ssh_encode(InData) ->
     ssh_file:encode(InData, ssh2_pubkey).
--else.
+-else. % OTP < 24
+-spec ssh_encode(binary()) -> binary().
+ssh_encode(InData) ->
+    public_key:ssh_encode(InData, ssh2_pubkey).
+-endif.
+-else. % OTP < 21
 -spec ssh_encode(binary()) -> binary().
 ssh_encode(InData) ->
     public_key:ssh_encode(InData, ssh2_pubkey).


### PR DESCRIPTION
Attempting to build with OTP-25.0-rc1 throws a warning:

`===> Compiling rebar3_hex
src/rebar3_hex_organization.erl:391:5: Warning: public_key:ssh_encode/2 is removed; use ssh_file:encode/2 instead`

which arguably should have been a hard error since the function is _gone_.

For some reason the ifdef:ery in `rebar3_hex_organization.erl` doesn't make the right choice for OTP-25.0-rc1, so I took the opportunity to rewrite it using the standard `OTP_RELEASE` macro. With this the build succeeds.
