### PR TITLE
Warn on prompt with instructions if no doc provider is configured

### DIFF
--- a/src/rebar3_hex_build.erl
+++ b/src/rebar3_hex_build.erl
@@ -142,6 +142,9 @@
     format_error/1
 ]).
 
+%% Helpers 
+-export([doc_opts/2]).
+
 %% ===================================================================
 %% Public API
 %% ===================================================================
@@ -518,6 +521,7 @@ resolve_dir(App, PrvName) ->
 docs_detected(DocDir) ->
     filelib:is_file(DocDir ++ "/index.html").
 
+-spec doc_opts(rebar_state:t(), map()) -> {ok, atom()} | undefined.
 doc_opts(State, Repo) ->
     case Repo of
         #{doc := #{provider := PrvName}} when is_atom(PrvName) ->

--- a/src/rebar3_hex_publish.erl
+++ b/src/rebar3_hex_publish.erl
@@ -518,7 +518,7 @@ maybe_warn_about_doc_config(State, Repo) ->
                                                " ",
                                                "{extras, [<<\"README.md\">>, <<\"LICENSE.md\">>]},",
                                                " ",
-                                               "{main, <<\"readme\">>}]}"
+                                               "{main, <<\"readme\">>}]}."
                                               ]
                                     );
         _ -> 


### PR DESCRIPTION
<img width="901" alt="Screen Shot 2022-04-10 at 5 13 26 PM" src="https://user-images.githubusercontent.com/39971740/162642062-bdb218c2-89f9-4092-8a96-f83f6de6e9c2.png">


This is quite verbose, maybe too verbose, but I figured giving some helpful instructions and being a little noisy is a good way to go here. Especially since this will become an error in 7.1. 

Edit: 

The only other thing I think we can add is link to docs for rebar3_hex. 