### PR TITLE
depencies are set to hexpm by default

### DIFF
--- a/src/rebar3_hex_app.erl
+++ b/src/rebar3_hex_app.erl
@@ -56,9 +56,9 @@ locks_to_deps(Deps) ->
     lists:foldl(fun(D, Acc) -> lock_to_dep(D, Acc) end, [], Deps).
 
 lock_to_dep({A, {pkg, N, V, _, _}, 0}, Acc) ->
-    [{N, [{<<"app">>, A}, {<<"optional">>, false}, {<<"requirement">>, V}]} | Acc];
+    [{N, [{<<"app">>, A}, {<<"optional">>, false}, {<<"repository">>,<<"hexpm">>}, {<<"requirement">>, V}]} | Acc];
 lock_to_dep({A, {pkg, N, V, _}, 0}, Acc) ->
-    [{N, [{<<"app">>, A}, {<<"optional">>, false}, {<<"requirement">>, V}]} | Acc];
+    [{N, [{<<"app">>, A}, {<<"optional">>, false}, {<<"repository">>,<<"hexpm">>}, {<<"requirement">>, V}]} | Acc];
 lock_to_dep(_, Acc) ->
     Acc.
 

--- a/test/rebar3_hex_app_SUITE.erl
+++ b/test/rebar3_hex_app_SUITE.erl
@@ -22,6 +22,7 @@ get_deps_test(_Config) ->
             {<<"verl">>, [
                 {<<"app">>, <<"verl">>},
                 {<<"optional">>, false},
+	        {<<"repository">>,<<"hexpm">>},
                 {<<"requirement">>, <<"1.1.1">>}
             ]}
         ]},


### PR DESCRIPTION
depencies are set to hexpm by default to avoid to research it on a private repository

fix #311 