### PR TITLE
Fix  issue with `hex cut` when no `-i` option is given (#316)

### DIFF
--- a/src/rebar3_hex_cut.erl
+++ b/src/rebar3_hex_cut.erl
@@ -138,8 +138,9 @@ format_error(Reason) ->
 %% Public API
 %% ===================================================================
 
-cut(State, Repo, App, #{increment := MaybeType} = Args) ->
+cut(State, Repo, App, #{} = Args) ->
     {Version, ResolvedVersion} = version_info(State, App),
+    MaybeType = maps:get(increment, Args, undefined),
     Type = get_increment(MaybeType, ResolvedVersion),
     NewVersion = increment_version(Type, ResolvedVersion),
     AppSrcFile = rebar_app_info:app_file_src(App),


### PR DESCRIPTION
The `-i` (increment) option is documented as optional but when not passed, it crashes `hex cut`. This fix makes it optional.