### PR TITLE
Handle case for build package where the error is a tagged tuple.

### DIFF
--- a/src/rebar3_hex_build.erl
+++ b/src/rebar3_hex_build.erl
@@ -142,7 +142,7 @@
     format_error/1
 ]).
 
-%% Helpers 
+%% Helpers
 -export([doc_opts/2]).
 
 %% ===================================================================
@@ -189,6 +189,9 @@ get_repo(State) ->
 %% @private
 -spec format_error(any()) -> iolist().
 format_error({build_package, Error}) when is_list(Error) ->
+    io_lib:format("Error building package : ~ts", [Error]);
+
+format_error({build_package, {error, Error}}) when is_list(Error) ->
     io_lib:format("Error building package : ~ts", [Error]);
 
 format_error({build_docs, {error, no_doc_config}}) ->


### PR DESCRIPTION
Caught while looking whether we handled a specific return from hex_core per https://github.com/hexpm/hex_core/pull/137 . We don't as hex_core doesn't return it, because hex_core matches on this and returns a friendly error, which is good :)  Yet we are failing to handle the shape of the error in this case. 