### PR TITLE
Do not attempt to format version for custom versions

### DIFF
--- a/src/rebar3_hex_cut.erl
+++ b/src/rebar3_hex_cut.erl
@@ -215,8 +215,8 @@ try_publish(State, Repo, App, Args) ->
 
 increment_version(other, _CurrentVersion) ->
      CustomVersion =  rebar3_hex_io:ask("New Version ", string),
-     Parsed = parse_version(CustomVersion),
-     rebar3_hex_version:format(Parsed);
+     _parsed = parse_version(CustomVersion),
+     rebar_utils:to_binary(CustomVersion);
 
 increment_version(Type, VersionStr) when is_list(VersionStr) orelse is_binary(VersionStr) ->
     Parsed = parse_version(VersionStr),


### PR DESCRIPTION
Currently if other is selected when running cut it will attempt format the version after  successfully parsing the version, however, we assume it is a simple increment and thus a simple version, which results in pre, build, and other information stripped from the version (i.e., negating why you chose other in the first place). 

Relates to #324 