### PR TITLE
Add option to opt-out of v prefix on tags / commits

### DIFF
--- a/src/rebar3_hex_cut.erl
+++ b/src/rebar3_hex_cut.erl
@@ -179,7 +179,7 @@ cut(State, Repo, App, #{} = Args) ->
     end.
 
 maybe_prefix_version(Vsn, true) ->
-    io_lib:format("v~s?", [Vsn]);
+    io_lib:format("v~s", [Vsn]);
 maybe_prefix_version(Vsn, false) ->
     Vsn.
 


### PR DESCRIPTION
This allows users to opt of of the `v` prefix for git tags and commits. 