### PR TITLE
A better TLDR of what's rebar3_hex [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@
 [![Docs](https://img.shields.io/badge/hex-docs-green.svg?style=flat)](https://hexdocs.pm/rebar3_hex)
 [![Erlang Versions](https://img.shields.io/badge/Supported%20Erlang%2FOTP-22.0%20to%2024.0-blue)](http://www.erlang.org)
 
-rebar3_hex is a rebar3 plugin which bundles providers for interacting with the Erlang ecosystem package manager [hex.pm](https://hex.pm/).
+rebar3_hex is a plugin for [Rebar3](https://www.rebar3.org/) that bundles providers to interact with [Hex](https://hex.pm/).
+
+> 💡 **rebar3_hex is a tool for package authors**  
+> If your Erlang project is not meant to be published on Hex, Rebar3 itself should be enough for you.
 
 ## Setup
 


### PR DESCRIPTION
Given that Rebar3 provides built-in support for a limited set of features related to Hex, and there has been multiple cases of confused developers looking to use rebar3_hex for basic usage (aka.: no package publishing), I  reworded the first paragraph (TLDR) of what is the project – along with a note of when it's required.

> _"The rebar3_hex plugin is required for publishing packages only. (...)"_  
> @tsloughter. https://github.com/erlef/rebar3_hex/issues/333#issuecomment-1971076725

Closes #333