### PR TITLE
Bump versions to latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         otp: ['25', '26', '27']
         rebar3: ['3.23.0']
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{matrix.otp}}
@@ -28,7 +28,7 @@ jobs:
       - name: Code coverage
         run: rebar3 as test do cover,covertool generate
       - name: Upload coverage report
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v4
         with:
           files: _build/test/covertool/rebar3_hex.covertool.xml
           name: ${{matrix.otp}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   test:
     name: Erlang/OTP ${{matrix.otp}} / rebar3 ${{matrix.rebar3}}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         otp: ['25', '26', '27']

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp: ['24', '25']
-        rebar3: ['3.16.1']
+        otp: ['25', '26', '27']
+        rebar3: ['3.23.0']
     steps:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1

--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,6 @@
 {erl_opts, [
     debug_info,
     {platform_define, "^2[3-9]", 'POST_OTP_22'},
-    {platform_define, "^23", 'OTP_23'},
     {platform_define, "^20", 'POST_OTP_19'},
     {platform_define, "^19", 'POST_OTP_18'},
     {platform_define, "^[2-9]", 'POST_OTP_18'}

--- a/rebar.config
+++ b/rebar.config
@@ -24,7 +24,8 @@
 
 {dialyzer, [
     {warnings, [
-        error_handling
+        error_handling,
+        no_unknown
     ]},
     {plt_extra_apps, [hex_core, verl]}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -9,7 +9,7 @@
     {platform_define, "^[2-9]", 'POST_OTP_18'}
 ]}.
 
-{project_plugins, [covertool, rebar3_ex_doc, {rebar3_hank, "~> 0.3.0"}]}.
+{project_plugins, [{covertool, "2.0.6"}, {rebar3_ex_doc, "0.2.23"}, {rebar3_hank, "0.3.0"}]}.
 
 {deps, [{hex_core, "0.10.1"}, {verl, "1.1.1"}]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -24,8 +24,7 @@
 
 {dialyzer, [
     {warnings, [
-        error_handling,
-        unknown
+        error_handling
     ]},
     {plt_extra_apps, [hex_core, verl]}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -15,7 +15,6 @@
 {profiles, [
     {test, [
         {extra_src_dirs, ["test/support"]},
-        {overrides, [{override, rebar3,[{deps, [{erlware_commons, "1.3.1"}]}]}]},
         {deps, [{hex_core, "0.10.1"},
                 {erlware_commons, "1.7.0"}, {elli, "3.3.0"},
                 {jsone, "1.8.1"}, {meck, "0.9.2"}]},

--- a/rebar.config
+++ b/rebar.config
@@ -25,7 +25,8 @@
 
 {dialyzer, [
     {warnings, [
-        error_handling
+        error_handling,
+        unknown
     ]},
     {plt_extra_apps, [hex_core, verl]}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -18,7 +18,7 @@
         {overrides, [{override, rebar3,[{deps, [{erlware_commons, "1.3.1"}]}]}]},
         {deps, [{hex_core, "0.10.1"},
                 {erlware_commons, "1.7.0"}, {elli, "3.3.0"},
-                {jsone, "1.5.3"}, {meck, "0.9.0"}]},
+                {jsone, "1.8.1"}, {meck, "0.9.0"}]},
         {erl_opts, [nowarn_export_all]}
     ]}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -15,8 +15,7 @@
 {profiles, [
     {test, [
         {extra_src_dirs, ["test/support"]},
-        {deps, [{hex_core, "0.10.1"},
-                {erlware_commons, "1.7.0"}, {elli, "3.3.0"},
+        {deps, [{erlware_commons, "1.7.0"}, {elli, "3.3.0"},
                 {jsone, "1.8.1"}, {meck, "0.9.2"}]},
         {erl_opts, [nowarn_export_all]}
     ]}

--- a/rebar.config
+++ b/rebar.config
@@ -17,7 +17,7 @@
         {extra_src_dirs, ["test/support"]},
         {overrides, [{override, rebar3,[{deps, [{erlware_commons, "1.3.1"}]}]}]},
         {deps, [{hex_core, "0.10.1"},
-                {erlware_commons, "1.5.0"}, {elli, "3.3.0"},
+                {erlware_commons, "1.7.0"}, {elli, "3.3.0"},
                 {jsone, "1.5.3"}, {meck, "0.9.0"}]},
         {erl_opts, [nowarn_export_all]}
     ]}

--- a/rebar.config
+++ b/rebar.config
@@ -8,7 +8,7 @@
     {platform_define, "^[2-9]", 'POST_OTP_18'}
 ]}.
 
-{project_plugins, [{covertool, "2.0.6"}, {rebar3_ex_doc, "0.2.23"}, {rebar3_hank, "0.3.0"}]}.
+{project_plugins, [{covertool, "2.0.6"}, {rebar3_ex_doc, "0.2.23"}, {rebar3_hank, "1.4.0"}]}.
 
 {deps, [{hex_core, "0.10.1"}, {verl, "1.1.1"}]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -18,7 +18,7 @@
         {overrides, [{override, rebar3,[{deps, [{erlware_commons, "1.3.1"}]}]}]},
         {deps, [{hex_core, "0.10.1"},
                 {erlware_commons, "1.7.0"}, {elli, "3.3.0"},
-                {jsone, "1.8.1"}, {meck, "0.9.0"}]},
+                {jsone, "1.8.1"}, {meck, "0.9.2"}]},
         {erl_opts, [nowarn_export_all]}
     ]}
 ]}.


### PR DESCRIPTION
This also:

- uses specific versions (and latest) for project plugins
- removes dead config. elements
- ups CI to include OTP 27
- moves `latest` to a specific version (Ubuntu runner)
- adds a new option `unknown` to Dialyzer's analysis config.