### PR TITLE
Fix Hex link to GitHub repository

### DIFF
--- a/src/rebar3_hex.app.src
+++ b/src/rebar3_hex.app.src
@@ -4,4 +4,4 @@
   {applications, [kernel,stdlib,hex_core]},
   {maintainers, ["Tristan Sloughter", "Bryan Paxton"]},
   {licenses, ["Apache-2.0"]},
-  {links, [{"Github", "https://github.com/tsloughter/rebar3_hex"}]}]}.
+  {links, [{"GitHub", "https://github.com/erlef/rebar3_hex"}]}]}.


### PR DESCRIPTION
It seems a GitHub redirect is already in place (saw it after I had fixed it locally and went to Hex.pm to confirm), but maybe this small change doesn't hurt (?)