### PR TITLE
Update whoami to expect some fields to be private

### DIFF
--- a/src/rebar3_hex_user.erl
+++ b/src/rebar3_hex_user.erl
@@ -368,16 +368,19 @@ whoami(#{name := Name} = Repo, State) ->
             ?RAISE(not_authenticated);
         ReadKey ->
             case rebar3_hex_client:me(Repo#{api_key => ReadKey}) of
-                {ok, #{<<"username">> := Username,
-                                       <<"email">> := Email}} ->
-                    rebar3_hex_io:say("~ts : ~ts (~ts)", [Name, Username, Email]),
+                {ok, #{<<"username">> := UserName} = Res} ->
+                    Header = ["Repo", "User Name", "Full Name", "Email"],
+                    FullName = maps:get(<<"full_name">>, Res, <<"private">>),
+                    Email = maps:get(<<"email">>, Res, <<"private">>),
+                    Body = [binary_to_list(Name), binary_to_list(UserName), binary_to_list(FullName), binary_to_list(Email)],
+                    ok = rebar3_hex_results:print_table([Header] ++ [Body]),
                     {ok, State};
                 {error, #{<<"message">> := Message}} ->
                     ?RAISE({whoami, Message});
                 Err  ->
                     ?RAISE({whoami, Err})
             end
-    end.
+      end.
 
 get_string_input(Prompt) ->
     MaxRetries = 3,

--- a/test/rebar3_hex_integration_SUITE.erl
+++ b/test/rebar3_hex_integration_SUITE.erl
@@ -1202,10 +1202,11 @@ setup_mocks_for(owner, #{password := Password} = Setup) ->
 
 setup_mocks_for(whoami, #{username := Username,
                           email := Email,
-                          repo := #{name := Name}}) ->
+                          repo := #{name := Name}} = Setup) ->
 
     Args =  [<<Name/binary>>, <<Username/binary>>, <<Email/binary>>],
     Expects = [{"~ts : ~ts (~ts)", Args}],
+    expects_repo_config(Setup),
     expects_output(Expects);
 
 setup_mocks_for(reset_password, #{username := Username}) ->


### PR DESCRIPTION
This resolves #345 where by it was shown that some fields may be marked as private such that no field exists in the result returned by hexpm (e.g., email address). 

This commit changes the result display to expect that, yet always expect at least a username. I've also updated it to display as pretty table output. 