### PR TITLE
Raise error if no lock file detected when building.

### DIFF
--- a/test/rebar3_hex_build_SUITE.erl
+++ b/test/rebar3_hex_build_SUITE.erl
@@ -8,6 +8,7 @@ all() ->
     [
         create_package_test,
         create_package_with_git_deps_test,
+        create_package_no_lock_file,
         create_package_with_alias_deps,
         create_package_with_binary_versions,
         create_docs_with_no_repo_set,
@@ -53,6 +54,11 @@ create_package_with_git_deps_test(Config) ->
     StubConfig = #{type => app, dir => data_dir(Config), name => "valid", profile => with_git_deps},
     {State, _Repo, App} = test_utils:make_stub(StubConfig),
     {error, _} = rebar3_hex_build:create_package(State, App).
+
+create_package_no_lock_file(Config) ->
+    StubConfig = #{type => app, dir => data_dir(Config), name => "no_lock_file", profile => no_lock_file},
+    {State, _Repo, App} = test_utils:make_stub(StubConfig),
+    ?assertError({error, {rebar3_hex_build, {create_package, no_lock_file}}}, rebar3_hex_build:create_package(State, App)).
 
 create_package_with_binary_versions(Config) ->
     StubConfig = #{type => app, dir => data_dir(Config), name => "valid", profile => with_binary_versions},

--- a/test/rebar3_hex_build_SUITE.erl
+++ b/test/rebar3_hex_build_SUITE.erl
@@ -58,7 +58,7 @@ create_package_with_git_deps_test(Config) ->
 create_package_no_lock_file(Config) ->
     StubConfig = #{type => app, dir => data_dir(Config), name => "no_lock_file", profile => no_lock_file},
     {State, _Repo, App} = test_utils:make_stub(StubConfig),
-    ?assertError({error, {rebar3_hex_build, {create_package, no_lock_file}}}, rebar3_hex_build:create_package(State, App)).
+    ?assertError({error, {rebar3_hex_build, {create_package, no_lock_file, _Profiles}}}, rebar3_hex_build:create_package(State, App)).
 
 create_package_with_binary_versions(Config) ->
     StubConfig = #{type => app, dir => data_dir(Config), name => "valid", profile => with_binary_versions},

--- a/test/support/test_utils.erl
+++ b/test/support/test_utils.erl
@@ -119,6 +119,9 @@ write_app_src_file(Dir, #{name := Name, app_src := #{version := Vsn}}) ->
     ok = filelib:ensure_dir(Filename),
     ok = ec_file:write_term(Filename, get_app_metadata(Name, Vsn)).
 
+write_lock_file(_, #{profile := no_lock_file}) ->
+  "rebar.lock";
+
 write_lock_file(Dir, #{profile := Profile}) ->
     Filename = filename:join([Dir, "rebar.lock"]),
     ok = filelib:ensure_dir(Filename),
@@ -149,8 +152,12 @@ config(with_git_deps) ->
 config(with_binary_versions) ->
     [{deps, [{hex_core, <<"0.8.2">>}, {verl, <<"1.1.1">>}]}];
 config(with_alias_deps) ->
-    [{deps, [{hex_core}, {verl}]}].
+    [{deps, [{hex_core}, {verl}]}];
+config(no_lock_file) ->
+  config(default).
 
+locks(no_lock_file) ->
+  [];
 locks(with_binary_versions) ->
     locks(default);
 locks(with_alias_deps) ->


### PR DESCRIPTION
Given that we can not check for the presence of non-hex deps without a lock file, we opt to bail if no lock file is detected on prior to creating a package, since under "normal" conditions the lock provider would have ran before the build and/or publish provider.

Closes #350 