### PR TITLE
allow building with OTP-29

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -8,6 +8,11 @@
     {platform_define, "^[2-9]", 'POST_OTP_18'}
 ]}.
 
+%% Some dependencies don't yet build cleanly with OTP-29.
+{overrides, [
+     {add, katana_code, [{erl_opts, [nowarn_deprecated_catch]}]}
+]}.
+
 {project_plugins, [{covertool, "2.0.6"}, {rebar3_ex_doc, "0.2.30"}, {rebar3_hank, "1.4.0"}]}.
 
 {deps, [{hex_core, "0.10.3"}, {verl, "1.1.1"}]}.

--- a/src/rebar3_hex_io.erl
+++ b/src/rebar3_hex_io.erl
@@ -133,11 +133,8 @@ get(integer, []) ->
 get(number, String) ->
     get(integer, String);
 get(integer, String) ->
-    case (catch list_to_integer(String)) of
-        {'Exit', _} ->
-            no_clue;
-        Integer ->
-            Integer
+    try list_to_integer(String)
+    catch _:_ -> no_clue
     end;
 get(string, []) ->
     no_data;


### PR DESCRIPTION
- fix old-style catch usage in `rebar3_hex_io` (it also had a broken match on `'Exit'` which should have been `'EXIT'`)
- enforce `nowarn_deprecated_catch` when building the `katana_code` dependency