### PR TITLE
Make `publish --revert --yes` skip the delete-tag prompt

### DIFF
--- a/src/rebar3_hex_publish.erl
+++ b/src/rebar3_hex_publish.erl
@@ -291,10 +291,10 @@ handle_task(#{apps := []}) ->
 handle_task(#{args := #{task := package, app := undefined}, multi_app := true}) ->
     ?RAISE({publish_package, app_switch_required});
 
-handle_task(#{args := #{task := package, revert := Vsn}, apps := [App]} = Task) ->
+handle_task(#{args := #{task := package, revert := Vsn, yes := Yes}, apps := [App]} = Task) ->
     #{repo := Repo, state := State} = Task,
     AppName = rebar_app_info:name(App),
-    revert_package(State, Repo, AppName, Vsn);
+    revert_package(State, Repo, AppName, Vsn, Yes);
 
 handle_task(#{args := #{task := package}, apps := [App]} = Task) ->
     maybe_warn_about_single_app_args(Task),
@@ -349,18 +349,18 @@ handle_task(#{args := #{task := docs, app := AppName}, apps := Apps} = Task) ->
 handle_task(#{args := #{revert := _, app := undefined}, multi_app := true}) ->
     ?RAISE({revert, app_switch_required});
 
-handle_task(#{args := #{revert := Vsn}, apps := [App]} = Task) ->
+handle_task(#{args := #{revert := Vsn, yes := Yes}, apps := [App]} = Task) ->
     #{repo := Repo, state := State} = Task,
     AppName = rebar_app_info:name(App),
-    revert_package(State, Repo, AppName, Vsn);
+    revert_package(State, Repo, AppName, Vsn, Yes);
 
-handle_task(#{args := #{revert := Vsn, app := AppName}, apps := Apps} = Task) ->
+handle_task(#{args := #{revert := Vsn, app := AppName, yes := Yes}, apps := Apps} = Task) ->
     #{repo := Repo, state := State} = Task,
     case rebar3_hex_app:find(Apps, AppName) of
         {error, app_not_found} ->
             ?RAISE({app_not_found, AppName});
         {ok, _App} ->
-            revert_package(State, Repo, AppName, Vsn)
+            revert_package(State, Repo, AppName, Vsn, Yes)
     end;
 
 %% ===================================================================
@@ -571,7 +571,7 @@ create_docs(State, Repo, App, Args) ->
 %%% package and doc reversion functions
 %%% ===================================================================
 
-revert_package(State, Repo, AppName, Vsn) ->
+revert_package(State, Repo, AppName, Vsn, Yes) ->
     BinAppName = rebar_utils:to_binary(AppName),
     BinVsn =  rebar_utils:to_binary(Vsn),
     assert_valid_version_arg(BinVsn),
@@ -579,15 +579,23 @@ revert_package(State, Repo, AppName, Vsn) ->
     case rebar3_hex_client:delete_release(HexConfig, BinAppName, BinVsn) of
         {ok, _} ->
             rebar_api:info("Successfully deleted package ~ts ~ts", [AppName, Vsn]),
-            Prompt = io_lib:format("Also delete tag v~ts?", [Vsn]),
-            case rebar3_hex_io:ask(Prompt, boolean, "N") of
-                true ->
-                    rebar_utils:sh(io_lib:format("git tag -d v~ts", [Vsn]), []);
-                _ ->
-                    {ok, State}
-            end;
+            maybe_delete_tag(State, Vsn, Yes);
         Reason ->
             ?RAISE({revert_package, BinAppName, BinVsn, Reason})
+    end.
+
+%% When --yes is given we run non-interactively and honor the prompt's default
+%% ("N"), keeping the tag.
+maybe_delete_tag(State, _Vsn, true) ->
+    {ok, State};
+maybe_delete_tag(State, Vsn, false) ->
+    Prompt = io_lib:format("Also delete tag v~ts?", [Vsn]),
+    case rebar3_hex_io:ask(Prompt, boolean, "N") of
+        true ->
+            rebar_utils:sh(io_lib:format("git tag -d v~ts", [Vsn]), []),
+            {ok, State};
+        _ ->
+            {ok, State}
     end.
 
 revert_docs(State, Repo, AppName, Vsn) ->

--- a/test/rebar3_hex_integration_SUITE.erl
+++ b/test/rebar3_hex_integration_SUITE.erl
@@ -66,6 +66,7 @@ all() ->
     , publish_docs_in_umbrella_when_does_not_exist_test
     , publish_replace_test
     , publish_revert_test
+    , publish_revert_with_yes_test
     , publish_revert_in_umbrella_test
     , publish_revert_in_umbrella_without_app_arg_test
     , publish_revert_in_umbrella_app_not_found_test
@@ -824,6 +825,20 @@ publish_revert_test(Config) ->
          },
     #{rebar_state := State} = Setup = setup_state(P, Config),
     expects_repo_config(Setup),
+    ?assertMatch({ok, State}, rebar3_hex_publish:do(State)).
+
+publish_revert_with_yes_test(Config) ->
+    P = #{
+          command => #{provider => rebar3_hex_publish, args => ["--revert", "1.0.0", "--yes"]},
+          app => #{name => "valid", version => "1.0.0", app_src => #{version => "1.0.0"}},
+          mocks => [publish]
+         },
+    #{rebar_state := State} = Setup = setup_state(P, Config),
+    expects_repo_config(Setup),
+    %% With --yes the revert must run non-interactively: the "Also delete tag"
+    %% prompt must never be shown.
+    meck:expect(rebar3_hex_io, ask,
+                fun(Prompt, _Type, _Str) -> erlang:error({unexpected_prompt, Prompt}) end),
     ?assertMatch({ok, State}, rebar3_hex_publish:do(State)).
 
 publish_revert_in_umbrella_test(Config) ->


### PR DESCRIPTION
This PR makes `publish --revert --yes` non-interactive. Previously `--revert <vsn> --yes` still prompted "Also delete tag v<vsn>?", which blocked CI. With `--yes`, the revert now keeps the local tag (the prompt's existing "N" default); interactive behavior is unchanged.

Closes #357